### PR TITLE
Adding public CI and analysis services, closes #4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # IDE
-.vscode
+#.vscode
 
 # vendor modules
 node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+dist: trusty
+sudo: false
+os:
+  - linux
+
+cache:
+  directories:
+    - '$HOME/.sonar/cache'
+
+before_script:
+    - export PROJECT_VERSION=$(node -e "console.log(require('./package.json').version);")
+
+install:  
+    - nvm install node
+    - npm install
+    - npm install -g coveralls
+
+script:
+    - nvm use node
+    - npm run lint
+    - npm run test-dev  
+
+after_success:
+    - coveralls < .coverage/unit/lcov.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,13 @@ before_script:
 install:  
 #    - nvm install node
     - npm install
-    - npm install -g coveralls
+    - npm install -g coveralls sonarqube-scanner
 
 script:
 #    - nvm use node
     - npm run lint
     - npm run test-dev  
+    - sonar-scanner -Dsonar.projectVersion=$PROJECT_VERSION -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONARCLOUD_TOKEN
 
 after_success:
     - coveralls < .coverage/lcov.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ os:
 
 cache:
   directories:
-    - '$HOME/.sonar/cache'
+    - '$HOME/.sonar'
+    - 'node_modules'
 
 before_script:
     - export PROJECT_VERSION=$(node -e "console.log(require('./package.json').version);")

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
-#dist: trusty
-#sudo: false
-#os:
-# - linux
-language: node_js
-node_js:
-  - "node"
+dist: trusty
+sudo: false
+os:
+- linux
 
 cache:
   directories:
@@ -14,12 +11,12 @@ before_script:
     - export PROJECT_VERSION=$(node -e "console.log(require('./package.json').version);")
 
 install:  
-#    - nvm install node
+    - nvm install node
     - npm install
     - npm install -g coveralls sonarqube-scanner
 
 script:
-#    - nvm use node
+    - nvm use node
     - npm run lint
     - npm run test-dev  
     - sonar-scanner -Dsonar.projectVersion=$PROJECT_VERSION -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONARCLOUD_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
-dist: trusty
-sudo: false
-os:
-  - linux
+#dist: trusty
+#sudo: false
+#os:
+# - linux
+language: node_js
+node_js:
+  - "node"
 
 cache:
   directories:
@@ -11,14 +14,14 @@ before_script:
     - export PROJECT_VERSION=$(node -e "console.log(require('./package.json').version);")
 
 install:  
-    - nvm install node
+#    - nvm install node
     - npm install
     - npm install -g coveralls
 
 script:
-    - nvm use node
+#    - nvm use node
     - npm run lint
     - npm run test-dev  
 
 after_success:
-    - coveralls < .coverage/unit/lcov.info
+    - coveralls < .coverage/lcov.info

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "GuardRex.status-bar-tasks",
+        "eg2.tslint",
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+    "files.exclude": {
+        "**/*.js": { "when": "$(basename).ts" },
+        "**/*.map": { "when": "$(basename).map" },
+        "npm-debug.log": true,
+        "node_modules": true,
+        ".coverage": true,
+        ".test-results": true,
+        ".nyc_output": true,
+        ".taskkey": true,
+        ".release": true
+    }
+}

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 [![Linux Build Badge][travis-ci-build-status-badge]][travis-ci-url]
 [![Coveralls Badge][coveralls-badge]][coveralls-url]
+[![Sonar Quality Gate][sonar-quality-gate-badge]][sonar-url]
 [![License Badge][license-badge]][repo-url]
 
 ## Overview
@@ -139,3 +140,5 @@ The Git logo is the orginal property of [Jason Long][jason-long-twitter-url] and
 [travis-ci-url]: https://travis-ci.org/swellaby/vsts-mirror-git-repository
 [coveralls-badge]: https://img.shields.io/coveralls/github/swellaby/vsts-mirror-git-repository.svg?style=flat-square
 [coveralls-url]: https://coveralls.io/github/swellaby/vsts-mirror-git-repository
+[sonar-quality-gate-badge]: https://sonarcloud.io/api/project_badges/measure?project=swellaby%3Avsts-mirror-git-repository&metric=alert_status&style=flat-square
+[sonar-url]: https://sonarcloud.io/dashboard?id=swellaby%3Avsts-mirror-git-repository

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Rating Badge][marketplace-rating-badge]][extension-marketplace-url]
 
 [![Linux Build Badge][travis-ci-build-status-badge]][travis-ci-url]
+[![AppVeyor Build Status][appveyor-build-status-badge]][appveyor-url]
 [![Coveralls Badge][coveralls-badge]][coveralls-url]
 [![Sonar Quality Gate][sonar-quality-gate-badge]][sonar-url]
 [![License Badge][license-badge]][repo-url]
@@ -138,6 +139,8 @@ The Git logo is the orginal property of [Jason Long][jason-long-twitter-url] and
 [vsts-secret-variable-group]: https://docs.microsoft.com/en-us/vsts/build-release/concepts/library/variable-groups
 [travis-ci-build-status-badge]: https://img.shields.io/travis/swellaby/vsts-mirror-git-repository.svg?label=linux%20build&style=flat-square
 [travis-ci-url]: https://travis-ci.org/swellaby/vsts-mirror-git-repository
+[appveyor-build-status-badge]: https://img.shields.io/appveyor/ci/swellaby/vsts-mirror-git-repository.svg?label=windows%20build&style=flat-square
+[appveyor-url]: https://ci.appveyor.com/project/swellaby/vsts-mirror-git-repository
 [coveralls-badge]: https://img.shields.io/coveralls/github/swellaby/vsts-mirror-git-repository.svg?style=flat-square
 [coveralls-url]: https://coveralls.io/github/swellaby/vsts-mirror-git-repository
 [sonar-quality-gate-badge]: https://sonarcloud.io/api/project_badges/measure?project=swellaby%3Avsts-mirror-git-repository&metric=alert_status&style=flat-square

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 [![Installs Badge][marketplace-installs-badge]][extension-marketplace-url]
 [![Rating Badge][marketplace-rating-badge]][extension-marketplace-url]
 
+[![Linux Build Badge][travis-ci-build-status-badge]][travis-ci-url]
+[![Coveralls Badge][coveralls-badge]][coveralls-url]
 [![License Badge][license-badge]][repo-url]
 
 ## Overview
@@ -123,7 +125,7 @@ The Git logo is the orginal property of [Jason Long][jason-long-twitter-url] and
 [license-badge]: https://img.shields.io/github/license/swellaby/vsts-mirror-git-repository.svg?style=flat-square
 [logo-image]: https://raw.githubusercontent.com/swellaby/vsts-mirror-git-repository/master/images/extension-icon.png
 [marketplace-version-badge]: https://img.shields.io/vscode-marketplace/v/swellaby.mirror-git-repository.svg?style=flat-square
-[marketplace-installs-badge]: https://img.shields.io/vscode-marketplace/d/swellaby.mirror-git-repository.svg?style=flat-square
+[marketplace-installs-badge]: https://vsmarketplacebadge.apphb.com/installs/swellaby.mirror-git-repository.svg?style=flat-square
 [marketplace-rating-badge]: https://img.shields.io/vscode-marketplace/r/swellaby.mirror-git-repository.svg?style=flat-square
 [mirror-instructions-url]: https://help.github.com/articles/duplicating-a-repository/#mirroring-a-repository-in-another-location
 [nodejs-url]: https://nodejs.org
@@ -133,3 +135,7 @@ The Git logo is the orginal property of [Jason Long][jason-long-twitter-url] and
 [vsts-pat-token-url]: https://docs.microsoft.com/en-us/vsts/accounts/use-personal-access-tokens-to-authenticate#create-personal-access-tokens-to-authenticate-access
 [vsts-secret-variables]: https://docs.microsoft.com/en-us/vsts/build-release/concepts/definitions/build/variables?tabs=batch#secret-variables
 [vsts-secret-variable-group]: https://docs.microsoft.com/en-us/vsts/build-release/concepts/library/variable-groups
+[travis-ci-build-status-badge]: https://img.shields.io/travis/swellaby/vsts-mirror-git-repository.svg?label=linux%20build&style=flat-square
+[travis-ci-url]: https://travis-ci.org/swellaby/vsts-mirror-git-repository
+[coveralls-badge]: https://img.shields.io/coveralls/github/swellaby/vsts-mirror-git-repository.svg?style=flat-square
+[coveralls-url]: https://coveralls.io/github/swellaby/vsts-mirror-git-repository

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,19 @@
+environment:
+  matrix:
+    - nodejs_version: "4"
+    - nodejs_version: "6"
+    - nodejs_version: "7"
+    - nodejs_version: "8"
+    - nodejs_version: "9"
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - npm install
+
+test_script:
+  - npm run lint
+  - npm run test-dev  
+
+build: off
+
+version: "{build}"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 environment:
   matrix:
-    - nodejs_version: "4"
     - nodejs_version: "6"
     - nodejs_version: "7"
     - nodejs_version: "8"

--- a/mocha-config.json
+++ b/mocha-config.json
@@ -1,6 +1,9 @@
 {
-    "reporterEnabled": "mocha-junit-reporter, spec",
+    "reporterEnabled": "mocha-junit-reporter, spec, mocha-sonarqube-reporter",
     "mochaJunitReporterReporterOptions": {
         "mochaFile": "./.test-results/test-results.xml"
+    },
+    "mochaSonarqubeReporterReporterOptions": {
+        "output": ".test-results/sonar.xml"
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,21 @@
                 "samsam": "1.3.0"
             }
         },
+        "@swellaby/nyc-config": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/@swellaby/nyc-config/-/nyc-config-0.0.4.tgz",
+            "integrity": "sha512-HaTjjYY6RV9IGFYKED23cvEAt4a4NE9gKCCD9DDAK4aO3/NO+Ob5UpTY27ba+4a0Sf0eEISc3tK18FhIBpxUlQ==",
+            "dev": true
+        },
+        "@swellaby/nyc-config-complete-coverage": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/@swellaby/nyc-config-complete-coverage/-/nyc-config-complete-coverage-0.0.4.tgz",
+            "integrity": "sha512-5f27qjQly6e+r2FmYYYcxwN5YsHtl4aOwT29lMW4XpbANwiy8CSwXEva67Uiz+cwf6NZVD6RnMTUZ0C04ynwxQ==",
+            "dev": true,
+            "requires": {
+                "@swellaby/nyc-config": "0.0.4"
+            }
+        },
         "@types/chai": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.2.tgz",
@@ -3264,6 +3279,910 @@
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
             "dev": true
         },
+        "fsevents": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+            "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "nan": "2.10.0",
+                "node-pre-gyp": "0.6.39"
+            },
+            "dependencies": {
+                "abbrev": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "ajv": {
+                    "version": "4.11.8",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "co": "4.6.0",
+                        "json-stable-stringify": "1.0.1"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "aproba": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "are-we-there-yet": {
+                    "version": "1.1.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "delegates": "1.0.0",
+                        "readable-stream": "2.2.9"
+                    }
+                },
+                "asn1": {
+                    "version": "0.2.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "assert-plus": {
+                    "version": "0.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "asynckit": {
+                    "version": "0.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "aws-sign2": {
+                    "version": "0.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "aws4": {
+                    "version": "1.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "balanced-match": {
+                    "version": "0.4.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "bcrypt-pbkdf": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "tweetnacl": "0.14.5"
+                    }
+                },
+                "block-stream": {
+                    "version": "0.0.9",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.3"
+                    }
+                },
+                "boom": {
+                    "version": "2.10.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "hoek": "2.16.3"
+                    }
+                },
+                "brace-expansion": {
+                    "version": "1.1.7",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "0.4.2",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "buffer-shims": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "caseless": {
+                    "version": "0.12.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "co": {
+                    "version": "4.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "code-point-at": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "combined-stream": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "delayed-stream": "1.0.0"
+                    }
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "console-control-strings": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "core-util-is": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "cryptiles": {
+                    "version": "2.0.5",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "boom": "2.10.1"
+                    }
+                },
+                "dashdash": {
+                    "version": "1.14.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "assert-plus": "1.0.0"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "debug": {
+                    "version": "2.6.8",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "deep-extend": {
+                    "version": "0.4.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "delayed-stream": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "delegates": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "detect-libc": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "ecc-jsbn": {
+                    "version": "0.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "jsbn": "0.1.1"
+                    }
+                },
+                "extend": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "extsprintf": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "forever-agent": {
+                    "version": "0.6.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "form-data": {
+                    "version": "2.1.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "asynckit": "0.4.0",
+                        "combined-stream": "1.0.5",
+                        "mime-types": "2.1.15"
+                    }
+                },
+                "fs.realpath": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "fstream": {
+                    "version": "1.0.11",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "inherits": "2.0.3",
+                        "mkdirp": "0.5.1",
+                        "rimraf": "2.6.1"
+                    }
+                },
+                "fstream-ignore": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "fstream": "1.0.11",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4"
+                    }
+                },
+                "gauge": {
+                    "version": "2.7.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "aproba": "1.1.1",
+                        "console-control-strings": "1.1.0",
+                        "has-unicode": "2.0.1",
+                        "object-assign": "4.1.1",
+                        "signal-exit": "3.0.2",
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1",
+                        "wide-align": "1.1.2"
+                    }
+                },
+                "getpass": {
+                    "version": "0.1.7",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "assert-plus": "1.0.0"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "glob": {
+                    "version": "7.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
+                "graceful-fs": {
+                    "version": "4.1.11",
+                    "bundled": true,
+                    "dev": true
+                },
+                "har-schema": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "har-validator": {
+                    "version": "4.2.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "ajv": "4.11.8",
+                        "har-schema": "1.0.5"
+                    }
+                },
+                "has-unicode": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "hawk": {
+                    "version": "3.1.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "boom": "2.10.1",
+                        "cryptiles": "2.0.5",
+                        "hoek": "2.16.3",
+                        "sntp": "1.0.9"
+                    }
+                },
+                "hoek": {
+                    "version": "2.16.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "http-signature": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "assert-plus": "0.2.0",
+                        "jsprim": "1.4.0",
+                        "sshpk": "1.13.0"
+                    }
+                },
+                "inflight": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "ini": {
+                    "version": "1.3.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "number-is-nan": "1.0.1"
+                    }
+                },
+                "is-typedarray": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "isstream": {
+                    "version": "0.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "jodid25519": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "jsbn": "0.1.1"
+                    }
+                },
+                "jsbn": {
+                    "version": "0.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "json-schema": {
+                    "version": "0.2.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "json-stable-stringify": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "jsonify": "0.0.0"
+                    }
+                },
+                "json-stringify-safe": {
+                    "version": "5.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "jsonify": {
+                    "version": "0.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "jsprim": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "assert-plus": "1.0.0",
+                        "extsprintf": "1.0.2",
+                        "json-schema": "0.2.3",
+                        "verror": "1.3.6"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "mime-db": {
+                    "version": "1.27.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "mime-types": {
+                    "version": "2.1.15",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "mime-db": "1.27.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "1.1.7"
+                    }
+                },
+                "minimist": {
+                    "version": "0.0.8",
+                    "bundled": true,
+                    "dev": true
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "minimist": "0.0.8"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "node-pre-gyp": {
+                    "version": "0.6.39",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "detect-libc": "1.0.2",
+                        "hawk": "3.1.3",
+                        "mkdirp": "0.5.1",
+                        "nopt": "4.0.1",
+                        "npmlog": "4.1.0",
+                        "rc": "1.2.1",
+                        "request": "2.81.0",
+                        "rimraf": "2.6.1",
+                        "semver": "5.3.0",
+                        "tar": "2.2.1",
+                        "tar-pack": "3.4.0"
+                    }
+                },
+                "nopt": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "abbrev": "1.1.0",
+                        "osenv": "0.1.4"
+                    }
+                },
+                "npmlog": {
+                    "version": "4.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "are-we-there-yet": "1.1.4",
+                        "console-control-strings": "1.1.0",
+                        "gauge": "2.7.4",
+                        "set-blocking": "2.0.0"
+                    }
+                },
+                "number-is-nan": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "oauth-sign": {
+                    "version": "0.8.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "object-assign": {
+                    "version": "4.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "os-homedir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "os-tmpdir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "osenv": {
+                    "version": "0.1.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "os-homedir": "1.0.2",
+                        "os-tmpdir": "1.0.2"
+                    }
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "performance-now": {
+                    "version": "0.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "process-nextick-args": {
+                    "version": "1.0.7",
+                    "bundled": true,
+                    "dev": true
+                },
+                "punycode": {
+                    "version": "1.4.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "qs": {
+                    "version": "6.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "rc": {
+                    "version": "1.2.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "deep-extend": "0.4.2",
+                        "ini": "1.3.4",
+                        "minimist": "1.2.0",
+                        "strip-json-comments": "2.0.1"
+                    },
+                    "dependencies": {
+                        "minimist": {
+                            "version": "1.2.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "readable-stream": {
+                    "version": "2.2.9",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "buffer-shims": "1.0.0",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "string_decoder": "1.0.1",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "request": {
+                    "version": "2.81.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "aws-sign2": "0.6.0",
+                        "aws4": "1.6.0",
+                        "caseless": "0.12.0",
+                        "combined-stream": "1.0.5",
+                        "extend": "3.0.1",
+                        "forever-agent": "0.6.1",
+                        "form-data": "2.1.4",
+                        "har-validator": "4.2.1",
+                        "hawk": "3.1.3",
+                        "http-signature": "1.1.1",
+                        "is-typedarray": "1.0.0",
+                        "isstream": "0.1.2",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "2.1.15",
+                        "oauth-sign": "0.8.2",
+                        "performance-now": "0.2.0",
+                        "qs": "6.4.0",
+                        "safe-buffer": "5.0.1",
+                        "stringstream": "0.0.5",
+                        "tough-cookie": "2.3.2",
+                        "tunnel-agent": "0.6.0",
+                        "uuid": "3.0.1"
+                    }
+                },
+                "rimraf": {
+                    "version": "2.6.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "glob": "7.1.2"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "semver": {
+                    "version": "5.3.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "set-blocking": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "signal-exit": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "sntp": {
+                    "version": "1.0.9",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "hoek": "2.16.3"
+                    }
+                },
+                "sshpk": {
+                    "version": "1.13.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "asn1": "0.2.3",
+                        "assert-plus": "1.0.0",
+                        "bcrypt-pbkdf": "1.0.1",
+                        "dashdash": "1.14.1",
+                        "ecc-jsbn": "0.1.1",
+                        "getpass": "0.1.7",
+                        "jodid25519": "1.0.2",
+                        "jsbn": "0.1.1",
+                        "tweetnacl": "0.14.5"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.0.1"
+                    }
+                },
+                "stringstream": {
+                    "version": "0.0.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
+                },
+                "strip-json-comments": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "tar": {
+                    "version": "2.2.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "block-stream": "0.0.9",
+                        "fstream": "1.0.11",
+                        "inherits": "2.0.3"
+                    }
+                },
+                "tar-pack": {
+                    "version": "3.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "debug": "2.6.8",
+                        "fstream": "1.0.11",
+                        "fstream-ignore": "1.0.5",
+                        "once": "1.4.0",
+                        "readable-stream": "2.2.9",
+                        "rimraf": "2.6.1",
+                        "tar": "2.2.1",
+                        "uid-number": "0.0.6"
+                    }
+                },
+                "tough-cookie": {
+                    "version": "2.3.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "punycode": "1.4.1"
+                    }
+                },
+                "tunnel-agent": {
+                    "version": "0.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "safe-buffer": "5.0.1"
+                    }
+                },
+                "tweetnacl": {
+                    "version": "0.14.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "uid-number": {
+                    "version": "0.0.6",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "util-deprecate": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "uuid": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "verror": {
+                    "version": "1.3.6",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "extsprintf": "1.0.2"
+                    }
+                },
+                "wide-align": {
+                    "version": "1.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "string-width": "1.0.2"
+                    }
+                },
+                "wrappy": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                }
+            }
+        },
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -5200,6 +6119,13 @@
             "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
             "integrity": "sha1-qSGZYKbV1dBGWXruUSUsZlX3F34=",
             "dev": true
+        },
+        "nan": {
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+            "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+            "dev": true,
+            "optional": true
         },
         "nanomatch": {
             "version": "1.2.9",
@@ -9900,6 +10826,7 @@
                         "anymatch": "2.0.0",
                         "async-each": "1.0.1",
                         "braces": "2.3.1",
+                        "fsevents": "1.1.3",
                         "glob-parent": "3.1.0",
                         "inherits": "2.0.3",
                         "is-binary-path": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6077,6 +6077,16 @@
                 }
             }
         },
+        "mocha-sonarqube-reporter": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/mocha-sonarqube-reporter/-/mocha-sonarqube-reporter-1.0.1.tgz",
+            "integrity": "sha1-o1j7P5jJ+HyDLBHenSAX16gZ+A4=",
+            "dev": true,
+            "requires": {
+                "mkdirp": "0.5.1",
+                "xml-escape": "1.1.0"
+            }
+        },
         "mockery": {
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
@@ -11607,6 +11617,12 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
             "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
+            "dev": true
+        },
+        "xml-escape": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.1.0.tgz",
+            "integrity": "sha1-OQTBQ/qOs6ADDsZG0pAqLxtwbEQ=",
             "dev": true
         },
         "xml2js": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
         "mocha": "^5.0.4",
         "mocha-junit-reporter": "^1.17.0",
         "mocha-multi-reporters": "^1.1.7",
+        "mocha-sonarqube-reporter": "^1.0.1",
         "nyc": "^11.4.1",
         "require-dir": "^1.0.0",
         "run-sequence": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
             "url": "https://github.com/traviskosarek"
         }
     ],
-    "license": "ISC",
+    "license": "MIT",
     "private": true,
     "dependencies": {
         "valid-url": "^1.0.9",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
         {
             "name": "Travis Kosarek",
             "url": "https://github.com/traviskosarek"
+        },
+        {
+            "name": "Caleb Cartwright",
+            "url": "https://github.com/calebcartwright"
         }
     ],
     "license": "MIT",
@@ -28,6 +32,7 @@
         "vsts-task-lib": "^2.3.0"
     },
     "devDependencies": {
+        "@swellaby/nyc-config-complete-coverage": "0.0.4",
         "@types/chai": "^4.1.2",
         "@types/mocha": "^2.2.48",
         "@types/node": "^9.4.7",
@@ -56,20 +61,13 @@
         "url": "https://github.com/swellaby/vsts-mirror-git-repository"
     },
     "nyc": {
-        "per-file": true,
+        "extends": "@swellaby/nyc-config-complete-coverage",
         "include": [
             "src/**/*.js"
         ],
         "exclude": [
             "src/**/*.spec.js"
         ],
-        "reporter": [
-            "text",
-            "html",
-            "cobertura"
-        ],
-        "cache": true,
-        "all": true,
         "report-dir": "./.coverage"
     }
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,7 +7,8 @@ sonar.links.ci=https://travis-ci.org/swellaby/vsts-mirror-git-repository
 sonar.links.scm=https://github.com/swellaby/vsts-mirror-git-repository
 sonar.links.issue=https://github.com/swellaby/vsts-mirror-git-repository/issues
 
-sonar.sources=src,!src/**/*.spec.ts
+sonar.sources=src/**/*.ts
+sonar.exclusions=src/**/*.spec.ts
 sonar.tests=src
 sonar.test.exclusions=src/**/git-mirror-task.ts
 sonar.language=ts

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,7 +8,8 @@ sonar.links.scm=https://github.com/swellaby/vsts-mirror-git-repository
 sonar.links.issue=https://github.com/swellaby/vsts-mirror-git-repository/issues
 
 sonar.sources=src
-sonar.tests=src/**/*.spec.ts
+sonar.tests=src
+sonar.test.exclusions=src/**/git-mirror-task.ts
 sonar.language=ts
 
 sonar.coverage.exclusions=src/**/*.spec.ts

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -17,4 +17,4 @@ sonar.coverage.exclusions=src/**/*.spec.ts
 
 #sonar.javascript.environments=node,mocha
 sonar.typescript.lcov.reportPaths=.coverage/unit/lcov.info
-sonar.testExecutionReportPaths=.testresults/sonar.xml
+sonar.testExecutionReportPaths=.test-results/sonar.xml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,10 +8,10 @@ sonar.links.scm=https://github.com/swellaby/vsts-mirror-git-repository
 sonar.links.issue=https://github.com/swellaby/vsts-mirror-git-repository/issues
 
 sonar.sources=src
-sonar.tests=src
+sonar.tests=src/**/*.spec.ts
 sonar.language=ts
 
-sonar.coverage.exclusions=src/*.spec.ts
+sonar.coverage.exclusions=src/**/*.spec.ts
 
 #sonar.javascript.environments=node,mocha
 sonar.typescript.lcov.reportPaths=.coverage/unit/lcov.info

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,18 @@
+sonar.projectKey=swellaby:vsts-mirror-git-repository
+sonar.projectName=VSTS Mirror Git Repository
+sonar.organization=swellaby
+
+sonar.links.homepage=https://github.com/swellaby
+sonar.links.ci=https://travis-ci.org/swellaby/vsts-mirror-git-repository
+sonar.links.scm=https://github.com/swellaby/vsts-mirror-git-repository
+sonar.links.issue=https://github.com/swellaby/vsts-mirror-git-repository/issues
+
+sonar.sources=src
+sonar.tests=src/*.spec.ts
+sonar.language=ts
+
+sonar.coverage.exclusions=src/*.spec.ts
+
+#sonar.javascript.environments=node,mocha
+sonar.typescript.lcov.reportPaths=.coverage/unit/lcov.info
+sonar.testExecutionReportPaths=.testresults/sonar.xml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,7 +7,7 @@ sonar.links.ci=https://travis-ci.org/swellaby/vsts-mirror-git-repository
 sonar.links.scm=https://github.com/swellaby/vsts-mirror-git-repository
 sonar.links.issue=https://github.com/swellaby/vsts-mirror-git-repository/issues
 
-sonar.sources=src/**/*.ts
+sonar.sources=src
 sonar.exclusions=src/**/*.spec.ts
 sonar.tests=src
 sonar.test.exclusions=src/**/git-mirror-task.ts

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -16,5 +16,5 @@ sonar.language=ts
 sonar.coverage.exclusions=src/**/*.spec.ts
 
 #sonar.javascript.environments=node,mocha
-sonar.typescript.lcov.reportPaths=.coverage/unit/lcov.info
+sonar.typescript.lcov.reportPaths=.coverage/lcov.info
 sonar.testExecutionReportPaths=.test-results/sonar.xml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,7 +8,7 @@ sonar.links.scm=https://github.com/swellaby/vsts-mirror-git-repository
 sonar.links.issue=https://github.com/swellaby/vsts-mirror-git-repository/issues
 
 sonar.sources=src
-sonar.tests=src/*.spec.ts
+sonar.tests=src
 sonar.language=ts
 
 sonar.coverage.exclusions=src/*.spec.ts

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,7 +7,7 @@ sonar.links.ci=https://travis-ci.org/swellaby/vsts-mirror-git-repository
 sonar.links.scm=https://github.com/swellaby/vsts-mirror-git-repository
 sonar.links.issue=https://github.com/swellaby/vsts-mirror-git-repository/issues
 
-sonar.sources=src
+sonar.sources=src,!src/**/*.spec.ts
 sonar.tests=src
 sonar.test.exclusions=src/**/git-mirror-task.ts
 sonar.language=ts


### PR DESCRIPTION
Updating with some hooks for public CI and some static analysis/code coverage services. @traviskosarek you are the primary maintainer of this repo so I am looking to you for final say on these items. 

This PR contains:
- [X] public Linux-based CI (TravisCI)
- [x] public windows-based CI (Appveyor)
- [x] static analysis via sonarcloud
- [X] inclusion of code coverage service/tracking (coveralls)
- [x] minor readme/metadata updates to add badges, etc.
- [X] add VS Code config files for workspace specific content

Closes #4 