### PR TITLE
Issue with SSL Certificate Verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,17 @@ The HTTPS endpoint of the Git Repository you want to copy from. This field is **
 **Source Repository - Personal Access Token**
 A Personal Access Token (PAT) that grants read access to the repository in the `Source Git Repository` field. This field is **optional**. If the Git repository in the `Source Git Repository` field is public, this field does not need to be populated. Check out the **Best Practices** section below for more details on managing PAT Tokens securely.
 
-**Verify SSL Certificate**
-Verifiying SSL certificates is a default behavior of Git. Unchecking this option will turn off SSL certificate validation as a part of the Source Repository cloning process. _If you are using a Git server with a Self-Signing certificate, you will likely need to uncheck this option._
+**Verify SSL Certificate on Source Repository**
+Verifiying SSL certificates is a default behavior of Git. Unchecking this option will turn off SSL certificate validation as a part of the Source Repository cloning process. _If you are using a Git server with a Self-Signing certificate, you may need to uncheck this option._
 
 **Destination Git Repository**
 The HTTPS endpoint of the Git Repository you want to copy to. This field is **required**.
 
 **Destination Repository - Personal Access Token**
 A Personal Access Token (PAT) that grants write access to the repository in the `Destination Git Repository` field. This field is **required**. Check out the **Best Practices** section below for more details on managing PAT Tokens securely.
+
+**Verify SSL Certificate on Destination Repository**
+Verifiying SSL certificates is a default behavior of Git. Unchecking this option will turn off SSL certificate validation as a part of the Destination Repository push process. _If you are using a Git server with a Self-Signing certificate, you will likely need to uncheck this option._
 
 <br/>
 

--- a/src/git-mirror/git-mirror-task.spec.ts
+++ b/src/git-mirror/git-mirror-task.spec.ts
@@ -428,14 +428,14 @@ describe("GitMirrorTask", () => {
             });
 
             const argIfStub = sandbox.stub(ToolRunner.prototype, "argIf").callsFake((conditionIsMet: boolean, arg: string) => {
-                if (conditionIsMet) {
-                    if (arg === "-c http.sslVerify=true") {
+                if (conditionIsMet && arg[0] !== undefined && arg[1] !== undefined) {
+                    if (arg[0] === "-c" && arg[1] === "http.sslVerify=true") {
                         isUsingSSLVerfication = true;
                     }
-                    else if (arg === "-c http.sslVerify=false") {
+                    else if (arg[0] === "-c" && arg[1] === "http.sslVerify=false") {
                         isUsingSSLVerfication = false;
                     }
-                }    
+                }
                 return new ToolRunner(arg);
             });
 
@@ -476,14 +476,14 @@ describe("GitMirrorTask", () => {
             });
 
             const argIfStub = sandbox.stub(ToolRunner.prototype, "argIf").callsFake((conditionIsMet: boolean, arg: string) => {
-                if (conditionIsMet) {
-                    if (arg === "-c http.sslVerify=true") {
+                if (conditionIsMet && arg[0] !== undefined && arg[1] !== undefined) {
+                    if (arg[0] === "-c" && arg[1] === "http.sslVerify=true") {
                         isUsingSSLVerfication = true;
                     }
-                    else if (arg === "-c http.sslVerify=false") {
+                    else if (arg[0] === "-c" && arg[1] === "http.sslVerify=false") {
                         isUsingSSLVerfication = false;
                     }
-                }
+                }    
                 return new ToolRunner(arg);
             });
 
@@ -521,11 +521,11 @@ describe("GitMirrorTask", () => {
             });
 
             const argIfStub = sandbox.stub(ToolRunner.prototype, "argIf").callsFake((conditionIsMet: boolean, arg: string) => {
-                if (conditionIsMet) {
-                    if (arg === "-c http.sslVerify=true") {
+                if (conditionIsMet && arg[0] !== undefined && arg[1] !== undefined) {
+                    if (arg[0] === "-c" && arg[1] === "http.sslVerify=true") {
                         isUsingSSLVerfication = true;
                     }
-                    else if (arg === "-c http.sslVerify=false") {
+                    else if (arg[0] === "-c" && arg[1] === "http.sslVerify=false") {
                         isUsingSSLVerfication = false;
                     }
                 }    

--- a/src/git-mirror/git-mirror-task.spec.ts
+++ b/src/git-mirror/git-mirror-task.spec.ts
@@ -11,9 +11,10 @@ import { GitMirrorTask } from "./git-mirror-task";
 
 let sourceUri;
 let sourcePAT;
+let sourceVerifySSLCertificate;
 let destinationUri;
 let destinationPAT;
-let verifySSLCertificate;
+let destinationVerifySSLCertificate;
 
 let getInputStub;
 let getBoolInputStub;
@@ -23,9 +24,10 @@ let sandbox;
 beforeEach(function() {
     sourceUri = "https://github.com/swellaby/vsts-mirror-git-repository";
     sourcePAT = "xxxxxxxxxx";
-    verifySSLCertificate = true;
+    sourceVerifySSLCertificate = true;
     destinationUri = "https://github.com/swellaby/vsts-mirror-git-repository";
     destinationPAT = "xxxxxxxxxx";
+    destinationVerifySSLCertificate = true;
 
     sandbox = sinon.sandbox.create();
 
@@ -35,7 +37,7 @@ beforeEach(function() {
                 if (required && sourceUri === undefined) {
                     throw new Error(name + " must be defined");
                 }
-                return sourceUri;    
+                return sourceUri;
             case "sourceGitRepositoryPersonalAccessToken":
                 if (required && sourcePAT === undefined) {
                     throw new Error(name + " must be defined");
@@ -59,11 +61,16 @@ beforeEach(function() {
 
     getBoolInputStub = sandbox.stub(taskLib, "getBoolInput").callsFake((name: string, required?: boolean) => {
         switch (name) {
-            case "verifySSLCertificate":
-                if (required && verifySSLCertificate === undefined) {
+            case "sourceVerifySSLCertificate":
+                if (required && sourceVerifySSLCertificate === undefined) {
                     throw new Error(name + " must be defined");
                 }
-                return verifySSLCertificate;
+                return sourceVerifySSLCertificate;
+            case "destinationVerifySSLCertificate":
+                if (required && destinationVerifySSLCertificate === undefined) {
+                    throw new Error(name + " must be defined");
+                }
+                return destinationVerifySSLCertificate;
             default:
                 console.log(name + " is not stubbed out in test");
                 throw new Error(name + " is not stubbed out in test");
@@ -90,7 +97,7 @@ describe("GitMirrorTask", () => {
                     taskSucceeded = false;
                 }
             });
-            
+
             const task = new GitMirrorTask();
 
             expect(taskSucceeded).to.be.true;
@@ -147,9 +154,9 @@ describe("GitMirrorTask", () => {
                     taskSucceeded = false;
                 }
             });
-            
+
             const task = new GitMirrorTask();
-            
+
             expect(taskSucceeded).to.be.false;
         });
 
@@ -168,7 +175,7 @@ describe("GitMirrorTask", () => {
             });
 
             const task = new GitMirrorTask();
-            
+
             expect(taskSucceeded).to.be.false;
         });
     });
@@ -195,16 +202,16 @@ describe("GitMirrorTask", () => {
 
             const gitCloneMirrorStub = sandbox.stub(task, "gitCloneMirror");
             gitCloneMirrorStub.returnsPromise().resolves(0);
-            
+
             const gitPushMirrorStub = sandbox.stub(task, "gitPushMirror");
             gitPushMirrorStub.returnsPromise().resolves(0);
 
             task.run();
-            
+
             expect(gitToolExists).to.be.true;
             expect(throwErrorIfGitDoesNotExist).to.be.true;
         });
-        
+
         it("should fail the task if the Git tool is not installed on the build agent", () => {
             let taskSucceeded = true;
 
@@ -215,7 +222,7 @@ describe("GitMirrorTask", () => {
             const whichStub = sandbox.stub(taskLib, "which").callsFake((tool: string, check?: boolean) => {
                 throw new Error("git tool does not exist");
             });
-            
+
             const setResultStub = sandbox.stub(taskLib, "setResult").callsFake((result: taskLib.TaskResult, message: string) => {
                 if (result === taskLib.TaskResult.Failed) {
                     taskSucceeded = false;
@@ -226,24 +233,24 @@ describe("GitMirrorTask", () => {
 
             const gitCloneMirrorStub = sandbox.stub(task, "gitCloneMirror");
             gitCloneMirrorStub.returnsPromise().resolves(0);
-            
+
             const gitPushMirrorStub = sandbox.stub(task, "gitPushMirror");
             gitPushMirrorStub.returnsPromise().resolves(0);
-            
+
             task.run();
-            
+
             expect(taskSucceeded).to.be.false;
         });
-        
+
         it("should successfully perform a git clone and git push", () => {
             let taskSucceeded = true;
-            
+
             const getVariablesStub = sandbox.stub(taskLib, "getVariables").callsFake(() => {
                 return ["1", "2", "3"];
             });
 
             const whichStub = sandbox.stub(taskLib, "which");
-            
+
             const setResultStub = sandbox.stub(taskLib, "setResult").callsFake((result: taskLib.TaskResult, message: string) => {
                 if (result === taskLib.TaskResult.Failed) {
                     taskSucceeded = false;
@@ -254,26 +261,26 @@ describe("GitMirrorTask", () => {
 
             const gitCloneMirrorStub = sandbox.stub(task, "gitCloneMirror");
             gitCloneMirrorStub.returnsPromise().resolves(0);
-            
+
             const gitPushMirrorStub = sandbox.stub(task, "gitPushMirror");
             gitPushMirrorStub.returnsPromise().resolves(0);
-            
+
             task.run();
-            
+
             expect(taskSucceeded).to.be.true;
             expect(gitCloneMirrorStub.called).to.be.true;
             expect(gitPushMirrorStub.called).to.be.true;
         });
-        
+
         it("should fail the task if the 'git clone --mirror ...' command throws an error", () => {
             let taskSucceeded = true;
-            
+
             const getVariablesStub = sandbox.stub(taskLib, "getVariables").callsFake(() => {
                 return ["1", "2", "3"];
             });
 
             const whichStub = sandbox.stub(taskLib, "which");
-            
+
             const setResultStub = sandbox.stub(taskLib, "setResult").callsFake((result: taskLib.TaskResult, message: string) => {
                 if (result === taskLib.TaskResult.Failed) {
                     taskSucceeded = false;
@@ -284,26 +291,26 @@ describe("GitMirrorTask", () => {
 
             const gitCloneMirrorStub = sandbox.stub(task, "gitCloneMirror");
             gitCloneMirrorStub.returnsPromise().resolves(1);
-            
+
             const gitPushMirrorStub = sandbox.stub(task, "gitPushMirror");
             gitPushMirrorStub.returnsPromise().resolves(0);
 
             task.run();
-            
+
             expect(taskSucceeded).to.be.false;
             expect(gitCloneMirrorStub.called).to.be.true;
             expect(gitPushMirrorStub.called).to.be.false;
         });
-        
+
         it("should fail the task if an error occurs when trying to invoke git clone mirror", () => {
             let taskSucceeded = true;
-            
+
             const getVariablesStub = sandbox.stub(taskLib, "getVariables").callsFake(() => {
                 return ["1", "2", "3"];
             });
 
             const whichStub = sandbox.stub(taskLib, "which");
-            
+
             const setResultStub = sandbox.stub(taskLib, "setResult").callsFake((result: taskLib.TaskResult, message: string) => {
                 if (result === taskLib.TaskResult.Failed) {
                     taskSucceeded = false;
@@ -314,12 +321,12 @@ describe("GitMirrorTask", () => {
 
             const gitCloneMirrorStub = sandbox.stub(task, "gitCloneMirror");
             gitCloneMirrorStub.returnsPromise().rejects();
-            
+
             const gitPushMirrorStub = sandbox.stub(task, "gitPushMirror");
             gitPushMirrorStub.returnsPromise().resolves(0);
-            
+
             task.run();
-            
+
             expect(taskSucceeded).to.be.false;
             expect(gitCloneMirrorStub.called).to.be.true;
             expect(gitPushMirrorStub.called).to.be.false;
@@ -327,13 +334,13 @@ describe("GitMirrorTask", () => {
 
         it("should fail the task if the 'git push --mirror ...' command throws an error", () => {
             let taskSucceeded = true;
-            
+
             const getVariablesStub = sandbox.stub(taskLib, "getVariables").callsFake(() => {
                 return ["1", "2", "3"];
             });
 
             const whichStub = sandbox.stub(taskLib, "which");
-            
+
             const setResultStub = sandbox.stub(taskLib, "setResult").callsFake((result: taskLib.TaskResult, message: string) => {
                 if (result === taskLib.TaskResult.Failed) {
                     taskSucceeded = false;
@@ -344,26 +351,26 @@ describe("GitMirrorTask", () => {
 
             const gitCloneMirrorStub = sandbox.stub(task, "gitCloneMirror");
             gitCloneMirrorStub.returnsPromise().resolves(0);
-            
+
             const gitPushMirrorStub = sandbox.stub(task, "gitPushMirror");
             gitPushMirrorStub.returnsPromise().resolves(1);
-            
+
             task.run();
-            
+
             expect(taskSucceeded).to.be.false;
             expect(gitCloneMirrorStub.called).to.be.true;
             expect(gitPushMirrorStub.called).to.be.true;
         });
-        
+
         it("should fail the task if an error occurs when trying to invoke git push mirror", () => {
             let taskSucceeded = true;
-            
+
             const getVariablesStub = sandbox.stub(taskLib, "getVariables").callsFake(() => {
                 return ["1", "2", "3"];
             });
 
             const whichStub = sandbox.stub(taskLib, "which");
-            
+
             const setResultStub = sandbox.stub(taskLib, "setResult").callsFake((result: taskLib.TaskResult, message: string) => {
                 if (result === taskLib.TaskResult.Failed) {
                     taskSucceeded = false;
@@ -374,12 +381,12 @@ describe("GitMirrorTask", () => {
 
             const gitCloneMirrorStub = sandbox.stub(task, "gitCloneMirror");
             gitCloneMirrorStub.returnsPromise().resolves(0);
-            
+
             const gitPushMirrorStub = sandbox.stub(task, "gitPushMirror");
             gitPushMirrorStub.returnsPromise().rejects();
-            
+
             task.run();
-            
+
             expect(taskSucceeded).to.be.false;
             expect(gitCloneMirrorStub.called).to.be.true;
             expect(gitPushMirrorStub.called).to.be.true;
@@ -390,23 +397,23 @@ describe("GitMirrorTask", () => {
         it("should construct and execute a 'git clone --mirror ...' task", () => {
             const authenticatedUri = "authenticatedUri";
             const shouldVerifySSLCertificate = true;
-            
+
             let usingGitTool = false;
             let isCloneUsed = false;
             let isMirrorOptionUsed = false;
             let isAuthenticatedUriUsed = false;
             let isUsingSSLVerfication = false;
-            
+
             const task = new GitMirrorTask();
 
-            const getVerifySSLCertificateStub = sandbox.stub(task, "getVerifySSLCertificate").callsFake(() => {
+            const getSourceVerifySSLCertificateStub = sandbox.stub(task, "getSourceVerifySSLCertificate").callsFake(() => {
                 return shouldVerifySSLCertificate;
             });
-            
+
             const getAuthenticatedGitUriStub = sandbox.stub(task, "getAuthenticatedGitUri").callsFake((uri: string, token: string) => {
                 return authenticatedUri;
             });
-            
+
             const toolStub = sandbox.stub(taskLib, "tool").callsFake((tool: string) => {
                 if (tool === "git") {
                     usingGitTool = true;
@@ -440,9 +447,9 @@ describe("GitMirrorTask", () => {
             });
 
             const execStub = sandbox.stub(ToolRunner.prototype, "exec");
-            
+
             task.gitCloneMirror();
-            
+
             expect(getAuthenticatedGitUriStub.called).to.be.true;
             expect(usingGitTool).to.be.true;
             expect(isCloneUsed).to.be.true;
@@ -454,19 +461,19 @@ describe("GitMirrorTask", () => {
         it("should enable SSL certificate verification", () => {
             const authenticatedUri = "authenticatedUri";
             const shouldVerifySSLCertificate = true;
-            
+
             let isUsingSSLVerfication = false;
-            
+
             const task = new GitMirrorTask();
-            
-            const getVerifySSLCertificateStub = sandbox.stub(task, "getVerifySSLCertificate").callsFake(() => {
+
+            const getSourceVerifySSLCertificateStub = sandbox.stub(task, "getSourceVerifySSLCertificate").callsFake(() => {
                 return shouldVerifySSLCertificate;
             });
 
             const getAuthenticatedGitUriStub = sandbox.stub(task, "getAuthenticatedGitUri").callsFake((uri: string, token: string) => {
                 return authenticatedUri;
             });
-            
+
             const toolStub = sandbox.stub(taskLib, "tool").callsFake((tool: string) => {
                 return new ToolRunner(tool);
             });
@@ -483,35 +490,35 @@ describe("GitMirrorTask", () => {
                     else if (arg[0] === "-c" && arg[1] === "http.sslVerify=false") {
                         isUsingSSLVerfication = false;
                     }
-                }    
+                }
                 return new ToolRunner(arg);
             });
 
             const execStub = sandbox.stub(ToolRunner.prototype, "exec");
-            
+
             task.gitCloneMirror();
-            
+
             expect(getAuthenticatedGitUriStub.called).to.be.true;
             expect(isUsingSSLVerfication).to.be.true;
             expect(execStub.called).to.be.true;
         });
 
-        it("should disable SSL certificate verification", () => {
+        it("should disablse SSL certificate verification", () => {
             const authenticatedUri = "authenticatedUri";
             const shouldVerifySSLCertificate = false;
-            
+
             let isUsingSSLVerfication = false;
-            
+
             const task = new GitMirrorTask();
-            
-            const getVerifySSLCertificateStub = sandbox.stub(task, "getVerifySSLCertificate").callsFake(() => {
+
+            const getSourceVerifySSLCertificateStub = sandbox.stub(task, "getSourceVerifySSLCertificate").callsFake(() => {
                 return shouldVerifySSLCertificate;
             });
 
             const getAuthenticatedGitUriStub = sandbox.stub(task, "getAuthenticatedGitUri").callsFake((uri: string, token: string) => {
                 return authenticatedUri;
             });
-            
+
             const toolStub = sandbox.stub(taskLib, "tool").callsFake((tool: string) => {
                 return new ToolRunner(tool);
             });
@@ -528,14 +535,14 @@ describe("GitMirrorTask", () => {
                     else if (arg[0] === "-c" && arg[1] === "http.sslVerify=false") {
                         isUsingSSLVerfication = false;
                     }
-                }    
+                }
                 return new ToolRunner(arg);
             });
 
             const execStub = sandbox.stub(ToolRunner.prototype, "exec");
-            
+
             task.gitCloneMirror();
-            
+
             expect(getAuthenticatedGitUriStub.called).to.be.true;
             expect(isUsingSSLVerfication).to.be.false;
             expect(execStub.called).to.be.true;
@@ -546,16 +553,22 @@ describe("GitMirrorTask", () => {
         it("should construct and execute a 'git push --mirror ...' task", () => {
             const sourceFolder = "sourceFolder";
             const authenticatedUri = "authenticatedUri";
-            
+            const shouldVerifySSLCertificate = true;
+
             let usingGitTool = false;
+            let isUsingSSLVerfication = false;
             let isCOptionUsed = false;
             let isSourceFolderUsed = false;
             let isPushUsed = false;
             let isMirrorOptionUsed = false;
             let isAuthenticatedUriUsed = false;
-            
+
             const task = new GitMirrorTask();
-            
+
+            const getDestinationVerifySSLCertificateStub = sandbox.stub(task, "getDestinationVerifySSLCertificate").callsFake(() => {
+                return shouldVerifySSLCertificate;
+            });
+
             const getSourceGitFolderStub = sandbox.stub(task, "getSourceGitFolder").callsFake((uri: string) => {
                 return sourceFolder;
             });
@@ -563,7 +576,7 @@ describe("GitMirrorTask", () => {
             const getAuthenticatedGitUriStub = sandbox.stub(task, "getAuthenticatedGitUri").callsFake((uri: string, token: string) => {
                 return authenticatedUri;
             });
-            
+
             const toolStub = sandbox.stub(taskLib, "tool").callsFake((tool: string) => {
                 if (tool === "git") {
                     usingGitTool = true;
@@ -580,7 +593,7 @@ describe("GitMirrorTask", () => {
                 }
                 else if (arg === "push") {
                     isPushUsed = true;
-                }    
+                }
                 else if (arg === "--mirror") {
                     isMirrorOptionUsed = true;
                 }
@@ -590,10 +603,155 @@ describe("GitMirrorTask", () => {
                 return new ToolRunner(arg);
             });
 
+            const argIfStub = sandbox.stub(ToolRunner.prototype, "argIf").callsFake((conditionIsMet: boolean, arg: string) => {
+                if (conditionIsMet && arg[0] !== undefined && arg[1] !== undefined) {
+                    if (arg[0] === "-c" && arg[1] === "http.sslVerify=true") {
+                        isUsingSSLVerfication = true;
+                    }
+                    else if (arg[0] === "-c" && arg[1] === "http.sslVerify=false") {
+                        isUsingSSLVerfication = false;
+                    }
+                }
+                return new ToolRunner(arg);
+            });
+
             const execStub = sandbox.stub(ToolRunner.prototype, "exec");
-            
+
             task.gitPushMirror();
-            
+
+            expect(getSourceGitFolderStub.called).to.be.true;
+            expect(getAuthenticatedGitUriStub.called).to.be.true;
+            expect(usingGitTool).to.be.true;
+            expect(isUsingSSLVerfication).to.be.true;
+            expect(isCOptionUsed).to.be.true;
+            expect(isSourceFolderUsed).to.be.true;
+            expect(isPushUsed).to.be.true;
+            expect(isMirrorOptionUsed).to.be.true;
+            expect(isAuthenticatedUriUsed).to.be.true;
+            expect(execStub.called).to.be.true;
+        });
+        
+        it("should enable SSL certificate verification", () => {
+            const sourceFolder = "sourceFolder";
+            const authenticatedUri = "authenticatedUri";
+            const shouldVerifySSLCertificate = true;
+
+            let isUsingSSLVerfication = false;
+
+            const task = new GitMirrorTask();
+
+            const getDestinationVerifySSLCertificateStub = sandbox.stub(task, "getDestinationVerifySSLCertificate").callsFake(() => {
+                return shouldVerifySSLCertificate;
+            });
+
+            const getSourceGitFolderStub = sandbox.stub(task, "getSourceGitFolder").callsFake((uri: string) => {
+                return sourceFolder;
+            });
+
+            const getAuthenticatedGitUriStub = sandbox.stub(task, "getAuthenticatedGitUri").callsFake((uri: string, token: string) => {
+                return authenticatedUri;
+            });
+
+            const toolStub = sandbox.stub(taskLib, "tool").callsFake((tool: string) => {
+                return new ToolRunner(tool);
+            });
+
+            const argStub = sandbox.stub(ToolRunner.prototype, "arg").callsFake((arg: string) => {
+                return new ToolRunner(arg);
+            });
+
+            const argIfStub = sandbox.stub(ToolRunner.prototype, "argIf").callsFake((conditionIsMet: boolean, arg: string) => {
+                if (conditionIsMet && arg[0] !== undefined && arg[1] !== undefined) {
+                    if (arg[0] === "-c" && arg[1] === "http.sslVerify=true") {
+                        isUsingSSLVerfication = true;
+                    }
+                    else if (arg[0] === "-c" && arg[1] === "http.sslVerify=false") {
+                        isUsingSSLVerfication = false;
+                    }
+                }
+                return new ToolRunner(arg);
+            });
+
+            const execStub = sandbox.stub(ToolRunner.prototype, "exec");
+
+            task.gitPushMirror();
+
+            expect(getSourceGitFolderStub.called).to.be.true;
+            expect(getAuthenticatedGitUriStub.called).to.be.true;
+            expect(isUsingSSLVerfication).to.be.true;
+            expect(execStub.called).to.be.true;
+        });
+        
+        it("should disablse SSL certificate verification", () => {
+            const sourceFolder = "sourceFolder";
+            const authenticatedUri = "authenticatedUri";
+            const shouldVerifySSLCertificate = false;
+
+            let isUsingSSLVerfication = false;
+
+            let usingGitTool = false;
+            let isCOptionUsed = false;
+            let isSourceFolderUsed = false;
+            let isPushUsed = false;
+            let isMirrorOptionUsed = false;
+            let isAuthenticatedUriUsed = false;
+
+            const task = new GitMirrorTask();
+
+            const getDestinationVerifySSLCertificateStub = sandbox.stub(task, "getDestinationVerifySSLCertificate").callsFake(() => {
+                return shouldVerifySSLCertificate;
+            });
+
+            const getSourceGitFolderStub = sandbox.stub(task, "getSourceGitFolder").callsFake((uri: string) => {
+                return sourceFolder;
+            });
+
+            const getAuthenticatedGitUriStub = sandbox.stub(task, "getAuthenticatedGitUri").callsFake((uri: string, token: string) => {
+                return authenticatedUri;
+            });
+
+            const toolStub = sandbox.stub(taskLib, "tool").callsFake((tool: string) => {
+                if (tool === "git") {
+                    usingGitTool = true;
+                }
+                return new ToolRunner(tool);
+            });
+
+            const argStub = sandbox.stub(ToolRunner.prototype, "arg").callsFake((arg: string) => {
+                if (arg === "-C") {
+                    isCOptionUsed = true;
+                }
+                else if (arg === sourceFolder) {
+                    isSourceFolderUsed = true;
+                }
+                else if (arg === "push") {
+                    isPushUsed = true;
+                }
+                else if (arg === "--mirror") {
+                    isMirrorOptionUsed = true;
+                }
+                else if (arg === authenticatedUri) {
+                    isAuthenticatedUriUsed = true;
+                }
+                return new ToolRunner(arg);
+            });
+
+            const argIfStub = sandbox.stub(ToolRunner.prototype, "argIf").callsFake((conditionIsMet: boolean, arg: string) => {
+                if (conditionIsMet && arg[0] !== undefined && arg[1] !== undefined) {
+                    if (arg[0] === "-c" && arg[1] === "http.sslVerify=true") {
+                        isUsingSSLVerfication = true;
+                    }
+                    else if (arg[0] === "-c" && arg[1] === "http.sslVerify=false") {
+                        isUsingSSLVerfication = false;
+                    }
+                }
+                return new ToolRunner(arg);
+            });
+
+            const execStub = sandbox.stub(ToolRunner.prototype, "exec");
+
+            task.gitPushMirror();
+
             expect(getSourceGitFolderStub.called).to.be.true;
             expect(getAuthenticatedGitUriStub.called).to.be.true;
             expect(usingGitTool).to.be.true;
@@ -606,10 +764,18 @@ describe("GitMirrorTask", () => {
         });
     });
 
-    describe("getVerifySSLCertificate", () => {
-        it("should return verify ssl certificate flag", () => {            
+    describe("getSourceVerifySSLCertificate", () => {
+        it("should return source verify ssl certificate flag", () => {
             const task = new GitMirrorTask();
-            task.getVerifySSLCertificate();
+            task.getSourceVerifySSLCertificate();
+            expect(true).to.be.true;
+        });
+    });
+
+    describe("getDestinationVerifySSLCertificate", () => {
+        it("should return destination verify ssl certificate flag", () => {
+            const task = new GitMirrorTask();
+            task.getDestinationVerifySSLCertificate();
             expect(true).to.be.true;
         });
     });
@@ -618,49 +784,49 @@ describe("GitMirrorTask", () => {
         it("should fail if the given URI is undefined", () => {
             const sourceGitUri = undefined;
             let isErrorThrown = false;
-            
+
             const task = new GitMirrorTask();
-            
+
             try {
                 const folder = task.getSourceGitFolder(sourceGitUri);
             }
             catch (e) {
                 isErrorThrown = true;
             }
-            
+
             expect(isErrorThrown).to.be.true;
         });
 
         it("should fail if the given URI is not a valid URI", () => {
             const sourceGitUri = "invalidUri";
             let isErrorThrown = false;
-            
+
             const task = new GitMirrorTask();
-            
+
             try {
                 const folder = task.getSourceGitFolder(sourceGitUri);
             }
             catch (e) {
                 isErrorThrown = true;
             }
-            
+
             expect(isErrorThrown).to.be.true;
         });
 
         it("should extract a folder name from a given uri", () => {
             const sourceGitUri = "https://github.com/swellaby/vsts-mirror-git-repository";
             let isErrorThrown = false;
-            
+
             const task = new GitMirrorTask();
             let folder;
-            
+
             try {
                 folder = task.getSourceGitFolder(sourceGitUri);
             }
             catch (e) {
                 isErrorThrown = true;
             }
-            
+
             expect(isErrorThrown).to.be.false;
             expect(folder).to.be.equal("vsts-mirror-git-repository.git");
         });
@@ -668,17 +834,17 @@ describe("GitMirrorTask", () => {
         it("should extract a folder name from a given uri with a .git extension", () => {
             const sourceGitUri = "https://github.com/swellaby/vsts-mirror-git-repository.git";
             let isErrorThrown = false;
-            
+
             const task = new GitMirrorTask();
             let folder;
-            
+
             try {
                 folder = task.getSourceGitFolder(sourceGitUri);
             }
             catch (e) {
                 isErrorThrown = true;
             }
-            
+
             expect(isErrorThrown).to.be.false;
             expect(folder).to.be.equal("vsts-mirror-git-repository.git");
         });
@@ -690,16 +856,16 @@ describe("GitMirrorTask", () => {
             const token = "token";
             let isErrorThrown = false;
             let authenticatedUri;
-            
+
             const task = new GitMirrorTask();
-            
+
             try {
                 authenticatedUri = task.getAuthenticatedGitUri(uri, token);
             }
             catch (e) {
                 isErrorThrown = true;
             }
-            
+
             expect(isErrorThrown).to.be.true;
         });
 
@@ -708,16 +874,16 @@ describe("GitMirrorTask", () => {
             const token = "token";
             let isErrorThrown = false;
             let authenticatedUri;
-            
+
             const task = new GitMirrorTask();
-            
+
             try {
                 authenticatedUri = task.getAuthenticatedGitUri(uri, token);
             }
             catch (e) {
                 isErrorThrown = true;
             }
-            
+
             expect(isErrorThrown).to.be.true;
         });
 
@@ -728,14 +894,14 @@ describe("GitMirrorTask", () => {
             let authenticatedUri;
 
             const task = new GitMirrorTask();
-            
+
             try {
                 authenticatedUri = task.getAuthenticatedGitUri(uri, token);
             }
             catch (e) {
                 isErrorThrown = true;
             }
-            
+
             expect(isErrorThrown).to.be.false;
             expect(authenticatedUri).to.be.equal(uri);
         });
@@ -747,14 +913,14 @@ describe("GitMirrorTask", () => {
             let authenticatedUri;
 
             const task = new GitMirrorTask();
-            
+
             try {
                 authenticatedUri = task.getAuthenticatedGitUri(uri, token);
             }
             catch (e) {
                 isErrorThrown = true;
             }
-            
+
             expect(isErrorThrown).to.be.false;
             expect(authenticatedUri).to.be.equal("http://" + token + "@" + "github.com/swellaby/vsts-mirror-git-repository");
         });
@@ -766,14 +932,14 @@ describe("GitMirrorTask", () => {
             let authenticatedUri;
 
             const task = new GitMirrorTask();
-            
+
             try {
                 authenticatedUri = task.getAuthenticatedGitUri(uri, token);
             }
             catch (e) {
                 isErrorThrown = true;
             }
-            
+
             expect(isErrorThrown).to.be.false;
             expect(authenticatedUri).to.be.equal("https://" + token + "@" + "github.com/swellaby/vsts-mirror-git-repository");
         });

--- a/src/git-mirror/git-mirror-task.ts
+++ b/src/git-mirror/git-mirror-task.ts
@@ -57,8 +57,8 @@ export class GitMirrorTask {
 
         return taskLib
             .tool("git")
-            .argIf(verifySSLCertificateFlag, "-c http.sslVerify=true")
-            .argIf(!verifySSLCertificateFlag, "-c http.sslVerify=false")
+            .argIf(verifySSLCertificateFlag, ["-c", "http.sslVerify=true"])
+            .argIf(!verifySSLCertificateFlag, ["-c", "http.sslVerify=false"])
             .arg("clone")
             .arg("--mirror")
             .arg(authenticatedSourceGitUrl)

--- a/src/git-mirror/git-mirror-task.ts
+++ b/src/git-mirror/git-mirror-task.ts
@@ -4,18 +4,20 @@ import * as validUrl from "valid-url";
 export class GitMirrorTask {
     private sourceGitRepositoryUri: string;
     private sourceGitRepositoryPersonalAccessToken: string;
+    private sourceVerifySSLCertificate: boolean;
     private destinationGitRepositoryUri: string;
     private destinationGitRepositoryPersonalAccessToken: string;
-    private verifySSLCertificate: boolean;
+    private destinationVerifySSLCertificate: boolean;
 
     public constructor() {
         try {
             if (this.taskIsRunnning()) {
                 this.sourceGitRepositoryUri = taskLib.getInput("sourceGitRepositoryUri", true);
                 this.sourceGitRepositoryPersonalAccessToken = taskLib.getInput("sourceGitRepositoryPersonalAccessToken", false);
-                this.verifySSLCertificate = taskLib.getBoolInput("verifySSLCertificate", false);
+                this.sourceVerifySSLCertificate = taskLib.getBoolInput("sourceVerifySSLCertificate", false);
                 this.destinationGitRepositoryUri = taskLib.getInput("destinationGitRepositoryUri", true);
                 this.destinationGitRepositoryPersonalAccessToken = taskLib.getInput("destinationGitRepositoryPersonalAccessToken", true);
+                this.destinationVerifySSLCertificate = taskLib.getBoolInput("destinationVerifySSLCertificate", false);
             }
         } catch (e) {
             taskLib.setResult(taskLib.TaskResult.Failed, e);
@@ -53,7 +55,7 @@ export class GitMirrorTask {
 
     public gitCloneMirror() {
         const authenticatedSourceGitUrl = this.getAuthenticatedGitUri(this.sourceGitRepositoryUri, this.sourceGitRepositoryPersonalAccessToken);
-        const verifySSLCertificateFlag = this.getVerifySSLCertificate();
+        const verifySSLCertificateFlag = this.getSourceVerifySSLCertificate();
 
         return taskLib
             .tool("git")
@@ -68,9 +70,12 @@ export class GitMirrorTask {
     public gitPushMirror() {
         const sourceGitFolder = this.getSourceGitFolder(this.sourceGitRepositoryUri);
         const authenticatedDestinationGitUrl = this.getAuthenticatedGitUri(this.destinationGitRepositoryUri, this.destinationGitRepositoryPersonalAccessToken);
+        const verifySSLCertificateFlag = this.getDestinationVerifySSLCertificate();
 
         return taskLib
             .tool("git")
+            .argIf(verifySSLCertificateFlag, ["-c", "http.sslVerify=true"])
+            .argIf(!verifySSLCertificateFlag, ["-c", "http.sslVerify=false"])
             .arg("-C")
             .arg(sourceGitFolder)
             .arg("push")
@@ -79,8 +84,12 @@ export class GitMirrorTask {
             .exec();
     }
 
-    public getVerifySSLCertificate(): boolean {
-        return this.verifySSLCertificate;
+    public getSourceVerifySSLCertificate(): boolean {
+        return this.sourceVerifySSLCertificate;
+    }
+
+    public getDestinationVerifySSLCertificate(): boolean {
+        return this.destinationVerifySSLCertificate;
     }
 
     public getSourceGitFolder(uri: string): string {

--- a/src/git-mirror/task.json
+++ b/src/git-mirror/task.json
@@ -29,14 +29,6 @@
             "defaultValue": ""
         },
         {
-            "name": "verifySSLCertificate",
-            "type": "boolean",
-            "label": "Verify SSL Certificate",
-            "defaultValue": "true",
-            "required": false,
-            "helpMarkDown": "Uncheck this option if you do not want Git to verify SSL certificates as a part of the cloning process"
-        },
-        {
             "name": "destinationGitRepositoryUri",
             "type": "string",
             "label": "Destination Git Repository",
@@ -51,6 +43,15 @@
             "required": true,
             "helpMarkDown": "A Personal Access Token that grants write access to the Git repository used as the Destination Git Repository",
             "defaultValue": ""
+        },
+        {
+            "name": "verifySSLCertificate",
+            "type": "boolean",
+            "label": "Verify SSL Certificate",
+            "defaultValue": "true",
+            "required": false,
+            "groupName": "Additional Options",
+            "helpMarkDown": "Uncheck this option if you do not want Git to verify SSL certificates as a part of the cloning process"
         }
     ],
     "execution": {

--- a/src/git-mirror/task.json
+++ b/src/git-mirror/task.json
@@ -29,6 +29,14 @@
             "defaultValue": ""
         },
         {
+            "name": "sourceVerifySSLCertificate",
+            "type": "boolean",
+            "label": "Verify SSL Certificate on Source Repository",
+            "defaultValue": "true",
+            "required": false,
+            "helpMarkDown": "Uncheck this option if you do not want Git to verify SSL certificates as a part of the cloning process"
+        },
+        {
             "name": "destinationGitRepositoryUri",
             "type": "string",
             "label": "Destination Git Repository",
@@ -45,13 +53,12 @@
             "defaultValue": ""
         },
         {
-            "name": "verifySSLCertificate",
+            "name": "destinationVerifySSLCertificate",
             "type": "boolean",
-            "label": "Verify SSL Certificate",
+            "label": "Verify SSL Certificate on Destination Repository",
             "defaultValue": "true",
             "required": false,
-            "groupName": "Additional Options",
-            "helpMarkDown": "Uncheck this option if you do not want Git to verify SSL certificates as a part of the cloning process"
+            "helpMarkDown": "Uncheck this option if you do not want Git to verify SSL certificates as a part of the push process"
         }
     ],
     "execution": {


### PR DESCRIPTION
The argument for the argIf option in vsts-task-lib needs all commands and options to be separated into an argument array so that it works correctly on all platforms.

The root cause of this issue is the format that was used. This PR fixes this issue and also adds the same functionality to the push command as well

This is tied to enhancement #6 and issue #8 