### PR TITLE
WIP - Do Not Merge! - Debugging

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
         "task-upload": "tfx build tasks upload --task-path .release/git-mirror/",
         "task-delete": "tfx build tasks delete --task-id 4e842f83-9438-4acb-994c-c8c31137dea9",
         "dev-setup": "npm i && npm run test-dev",
-        "dev-reset": "npm run clean && node -e \"require('rimraf').sync('node_modules');\" && npm run dev-setup"
+        "dev-reset": "npm run clean && node -e \"require('rimraf').sync('node_modules');\" && npm run dev-setup",
+        "run-local": "npm run clean && tsc && node src/git-mirror/git-mirror-task.js",
+        "run-local-bundled": "npm run build && node .release/git-mirror/git-mirror-task.js"
     },
     "author": {
         "name": "swellaby",

--- a/src/git-mirror/git-mirror-task.ts
+++ b/src/git-mirror/git-mirror-task.ts
@@ -14,12 +14,18 @@ export class GitMirrorTask {
     public constructor() {
         try {
             if (this.taskIsRunning()) {
-                this.sourceGitRepositoryUri = taskLib.getInput("sourceGitRepositoryUri", true);
-                this.sourceGitRepositoryPersonalAccessToken = taskLib.getInput("sourceGitRepositoryPersonalAccessToken", false);
-                this.sourceVerifySSLCertificate = taskLib.getBoolInput("sourceVerifySSLCertificate", false);
-                this.destinationGitRepositoryUri = taskLib.getInput("destinationGitRepositoryUri", true);
-                this.destinationGitRepositoryPersonalAccessToken = taskLib.getInput("destinationGitRepositoryPersonalAccessToken", true);
-                this.destinationVerifySSLCertificate = taskLib.getBoolInput("destinationVerifySSLCertificate", false);
+                // this.sourceGitRepositoryUri = taskLib.getInput("sourceGitRepositoryUri", true);
+                // this.sourceGitRepositoryPersonalAccessToken = taskLib.getInput("sourceGitRepositoryPersonalAccessToken", false);
+                // this.sourceVerifySSLCertificate = taskLib.getBoolInput("sourceVerifySSLCertificate", false);
+                // this.destinationGitRepositoryUri = taskLib.getInput("destinationGitRepositoryUri", true);
+                // this.destinationGitRepositoryPersonalAccessToken = taskLib.getInput("destinationGitRepositoryPersonalAccessToken", true);
+                // this.destinationVerifySSLCertificate = taskLib.getBoolInput("destinationVerifySSLCertificate", false);
+                this.sourceGitRepositoryUri = "https://github.com/Jamesits/some-private-repo";
+                this.sourceGitRepositoryPersonalAccessToken = null;
+                this.sourceVerifySSLCertificate = false;
+                this.destinationGitRepositoryUri = "somewhere";
+                this.destinationGitRepositoryPersonalAccessToken = null;
+                this.destinationVerifySSLCertificate = false;
             }
         } catch (e) {
             taskLib.setResult(taskLib.TaskResult.Failed, e);
@@ -28,10 +34,13 @@ export class GitMirrorTask {
 
     public async run() {
         if (this.taskIsRunning()) {
+            console.log("****************");
+            console.log("inside run check");
             try {
                 // check if git exists as a tool
                 taskLib.which("git", true);
                 const cloneMirrorResponseCode = await this.gitCloneMirror();
+                console.log(`mirror response code: ${cloneMirrorResponseCode}`);
                 if (cloneMirrorResponseCode !== 0) {
                     taskLib.setResult(taskLib.TaskResult.Failed, "An error occurred when attempting to clone the source repository. Please check output for more details.");
                     return;
@@ -45,13 +54,16 @@ export class GitMirrorTask {
                 }
 
             } catch (e) {
+                console.log(`down inside run catch block. error: ${e}`);
                 taskLib.setResult(taskLib.TaskResult.Failed, e);
             }
         }
     }
 
     public gitCloneMirror() {
+        console.log("about to get source uri");
         const authenticatedSourceGitUrl = this.getAuthenticatedGitUri(this.sourceGitRepositoryUri, this.sourceGitRepositoryPersonalAccessToken);
+        console.log(`got source uri: ${authenticatedSourceGitUrl}`);
         const verifySSLCertificateFlag = this.getSourceVerifySSLCertificate();
         return taskLib
             .tool("git")
@@ -66,9 +78,9 @@ export class GitMirrorTask {
     public async removePullRequestRefs(): Promise<void> {
         return new Promise<void>((resolve, reject) => {
             try {
+                console.log("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&");
                 const sourceGitFolder = this.getSourceGitFolder(this.sourceGitRepositoryUri);
                 const packedRefsFileName = resolvePath(joinPath(".", `${sourceGitFolder}/packed-refs`));
-
                 readFile(packedRefsFileName, "utf8", (err, data) => {
                     if (err) {
                         reject(err);
@@ -139,9 +151,11 @@ export class GitMirrorTask {
     }
 
     private taskIsRunning(): number {
-        return taskLib.getVariables().length;
+        return 1;
+        // return taskLib.getVariables().length;
     }
 }
 
 const gitMirrorTask = new GitMirrorTask();
+console.log("about to run");
 gitMirrorTask.run();


### PR DESCRIPTION
This PR is for discussions/debugging around #31 using the bug/31 branch. 

I've tweaked the task source to make it easy to run locally (hardcoded input variables, etc.), obviously just for debugging on this branch, not to actually be merged/published. 

I added two new npm scripts to support running the task locally:

* `npm run run-local` - runs the js file as-emitted by tsc (no webpack bundling)
* `npm run run-local-bundled` - runs the bundled/packaged js as created by webpack (how the task currently runs in prod)

The first one runs exactly like we'd expect (it fails gracefully while attempting to clone a private repo without a token/auth). However, the latter crashes hard on the mirror step, so hard that execution flow is lost and the task ends up as succeeded (because it's never set to failed).

Execution gets down to the `exec()` call on line 78 (of the source TS file), but that's about as much as I can glean from this. My best guess right now is that webpack is somehow incorrectly bundling parts of the task lib (`azure-pipelines-task-lib`) and that is surfacing when the `exec` call fails

Thoughts?