### PR TITLE
feat: add source repo clone dir input

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,11 @@ The HTTPS endpoint of the Git Repository you want to copy from. This field is **
 **Source Repository - Personal Access Token**
 A Personal Access Token (PAT) that grants read access to the repository in the `Source Git Repository` field. This field is **optional**. If the Git repository in the `Source Git Repository` field is public, this field does not need to be populated. Check out the **Best Practices** section below for more details on managing PAT Tokens securely.
 
+**Source Repository - Clone Directory Name**
+The name of the directory to clone the Source Repository into. This field is **optional**. This is the same [<directory> argument][git-clone-doc-url] used by `git clone` with the same default behavior.
+
 **Verify SSL Certificate on Source Repository**
-Verifiying SSL certificates is a default behavior of Git. Unchecking this option will turn off SSL certificate validation as a part of the Source Repository cloning process. _If you are using a Git server with a Self-Signing certificate, you may need to uncheck this option._
+Verifying SSL certificates is a default behavior of Git. Disabling this option will turn off SSL certificate validation as a part of the Source Repository cloning process. _If you are using a Git server with a Self-Signing certificate, you may need to uncheck this option._
 
 **Destination Git Repository**
 The HTTPS endpoint of the Git Repository you want to copy to. This field is **required**.
@@ -50,12 +53,13 @@ When using the Mirror Git Repository task in a YAML-based pipeline, the task con
 
 * `sourceGitRepositoryUri`
 * `sourceGitRepositoryPersonalAccessToken` 
+* `sourceGitRepositoryCloneDirectoryName`
 * `sourceVerifySSLCertificate` (defaults to `true`)
 * `destinationGitRepositoryUri`
 * `destinationGitRepositoryPersonalAccessToken`
 * `destinationVerifySSLCertificate` (defaults to `true`)
 
-You may omit the access token inputs (`sourceGitRepositoryPersonalAccessToken` and `destinationGitRepositoryPersonalAccessToken`) if you do not need to provide a token for the respective source/destination repo. You may also omit the SSL verification inputs (`sourceVerifySSLCertificate` and `destinationVerifySSLCertificate`) if you want to include SSL verification (the only time you _have_ to provide those inputs is if you need to set the value to false)
+You may omit the access token inputs (`sourceGitRepositoryPersonalAccessToken` and `destinationGitRepositoryPersonalAccessToken`) if you do not need to provide a token for the respective source/destination repo. You may omit the source repository clone directory name (`sourceGitRepositoryCloneDirectoryName`) if you do not need to override the default behavior of `git clone`. You may also omit the SSL verification inputs (`sourceVerifySSLCertificate` and `destinationVerifySSLCertificate`) if you want to include SSL verification (the only time you _have_ to provide those inputs is if you need to set the value to false)
 
 Here's an example snippet of what a YAML configuration would like like for the Mirror Git Repository Task (using a secure variable for the destination token)
 
@@ -78,11 +82,11 @@ Here's an example snippet of what a YAML configuration would like like for the M
 In order to use this task, you will need to create Personal Access Tokens to the appropriate repositories. Below are some links on how to achieve this:
 
 - [How to create a Personal Access Token on Github][github-pat-token-url]
-- [How to create a Personal Access Token on VSTS][vsts-pat-token-url]
+- [How to create a Personal Access Token on Azure DevOps][vsts-pat-token-url]
 
 ### Securing Personal Access Tokens during the build
 
-While you have the ability to enter the PAT tokens into the task in plain-text, it is best practice to mask these tokens so that your repositories remain secure. VSTS supports the ability to manage and inject secure variables at build time. There are currently two ways to achieve this in VSTS:
+While you have the ability to enter the PAT tokens into the task in plain-text, it is best practice to mask these tokens so that your repositories remain secure. Azure Pipelines supports the ability to manage and inject secure variables at build time. There are currently two ways to achieve this in Azure Pipelines:
 
 1. [Use a Secret Process Variable directly on the build definition][vsts-secret-variables]
 2. [Use a Secret variable from a Variable Group linked to the build definition][vsts-secret-variable-group]
@@ -101,7 +105,7 @@ This task is built solely on top of [Git][git-url] commands. As long as the buil
 
 ### Why should I choose this task over one of the other Git mirroring tasks available on the marketplace?
 
-&nbsp;&nbsp;&nbsp;&nbsp;_**tl;dr** It is the only mirroring task that currently works without needing to modify the VSTS Build Agent Docker Image to include Powershell_
+&nbsp;&nbsp;&nbsp;&nbsp;_**tl;dr** It is the only mirroring task that currently works without needing to modify the Azure Pipelines Build Agent Docker Image to include Powershell_
 
 As of this task being published, the other tasks on the Marketplace that perform similar actions are written with Powershell scripts and do not work out-of-the-box with the [VSTS Build Agent Docker Image][docker-vsts-agent-url]. To fill this gap, we decided to develop our own task that is written in [NodeJS][nodejs-url]. *Note that this task does require the build agent to have [NodeJS][nodejs-url] installed.*
 
@@ -130,7 +134,7 @@ Some things to check if you are experiencing this issue:
 1. Check that both of the Git Repository URLs you provided are correct.
 2. You may need to include a Personal Access Token to give the build agent access to the Git Repository.
 
-&nbsp;&nbsp;&nbsp;&nbsp;_Note: The task does not give the build agent read or write access to your VSTS repositories by default._
+&nbsp;&nbsp;&nbsp;&nbsp;_Note: The task does not give the build agent read or write access to your Azure DevOps repositories by default._
 
 ### I have other questions and/or need to report an issue
 
@@ -140,7 +144,7 @@ Please report any issues to our [Github Issues page][repo-issues-url], quick lin
 - [Request an enhancement or feature][create-enhancement-url]
 - [Ask a question][create-question-url]
 
-Feel free to leave a question or a comment on our [Github repo][repo-url] or on the [VSTS Task in the Marketplace][extension-marketplace-url].
+Feel free to leave a question or a comment on our [Github repo][repo-url] or on the [Extension in the Marketplace][extension-marketplace-url].
 
 <br/>
 
@@ -149,7 +153,7 @@ Contributions are welcomed and encouraged! More details can be found in the [Con
 
 ## Generator
 
-Want to make your own VSTS Task? This task was initially created by this [swell generator][parent-generator-url]!
+Want to make your own Azure Pipelines Extension or Task? This task was initially created by this [swell generator][parent-generator-url]!
 
 <br/>
 
@@ -191,4 +195,5 @@ The Git logo is the orginal property of [Jason Long][jason-long-twitter-url] and
 [create-question-url]: https://github.com/swellaby/vsts-mirror-git-repository/issues/new?template=QUESTION_TEMPLATE.md&labels=question,unreviewed&title=Q:%20
 [create-enhancement-url]: https://github.com/swellaby/vsts-mirror-git-repository/issues/new?template=ENHANCEMENT_TEMPLATE.md&labels=enhancement,unreviewed
 [contribution-guidelines]: ./.github/CONTRIBUTING.md
+[git-clone-doc-url]: https://git-scm.com/docs/git-clone#Documentation/git-clone.txt-ltdirectorygt
 [top]: #mirror-git-repository

--- a/package-lock.json
+++ b/package-lock.json
@@ -321,12 +321,12 @@
             },
             "dependencies": {
                 "async": {
-                    "version": "2.6.2",
-                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
-                    "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+                    "version": "2.6.3",
+                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+                    "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
                     "dev": true,
                     "requires": {
-                        "lodash": "^4.17.11"
+                        "lodash": "^4.17.14"
                     }
                 }
             }
@@ -397,12 +397,11 @@
             "dev": true
         },
         "azure-devops-node-api": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-7.2.0.tgz",
-            "integrity": "sha512-pMfGJ6gAQ7LRKTHgiRF+8iaUUeGAI0c8puLaqHLc7B8AR7W6GJLozK9RFeUHFjEGybC9/EB3r67WPd7e46zQ8w==",
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-8.1.1.tgz",
+            "integrity": "sha512-TIb69NbHOJ/OTvfI1iazMzw/wG9A+ORCYibZCf5wDQFUyYzjCNVUA9QskAW1BGOulwyulGpqWXClCo4KoBaP0Q==",
             "dev": true,
             "requires": {
-                "os": "0.1.1",
                 "tunnel": "0.0.4",
                 "typed-rest-client": "1.2.0",
                 "underscore": "1.8.3"
@@ -427,9 +426,9 @@
             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "base64-js": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-            "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+            "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
             "dev": true
         },
         "bl": {
@@ -458,9 +457,9 @@
             "dev": true
         },
         "buffer": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
-            "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+            "version": "5.4.3",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+            "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
             "dev": true,
             "requires": {
                 "base64-js": "^1.0.2",
@@ -928,10 +927,26 @@
             }
         },
         "deep-equal": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-            "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
-            "dev": true
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.0.tgz",
+            "integrity": "sha512-ZbfWJq/wN1Z273o7mUSjILYqehAktR2NVoSrOukDkU9kg2v/Uv89yU4Cvz8seJeAmtN5oqiefKq8FPuXOboqLw==",
+            "dev": true,
+            "requires": {
+                "is-arguments": "^1.0.4",
+                "is-date-object": "^1.0.1",
+                "is-regex": "^1.0.4",
+                "object-is": "^1.0.1",
+                "object-keys": "^1.1.1",
+                "regexp.prototype.flags": "^1.2.0"
+            },
+            "dependencies": {
+                "object-keys": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+                    "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+                    "dev": true
+                }
+            }
         },
         "default-require-extensions": {
             "version": "2.0.0",
@@ -1361,6 +1376,12 @@
             "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
             "dev": true
         },
+        "is-arguments": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+            "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
+            "dev": true
+        },
         "is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -1628,6 +1649,12 @@
             "requires": {
                 "handlebars": "^4.1.0"
             }
+        },
+        "jju": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+            "integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo=",
+            "dev": true
         },
         "js-tokens": {
             "version": "4.0.0",
@@ -2684,6 +2711,12 @@
                 }
             }
         },
+        "object-is": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
+            "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY=",
+            "dev": true
+        },
         "object-keys": {
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
@@ -2766,12 +2799,6 @@
                     "dev": true
                 }
             }
-        },
-        "os": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/os/-/os-0.1.1.tgz",
-            "integrity": "sha1-IIhF6J4ZOtTZcUdLk5R3NqVtE/M=",
-            "dev": true
         },
         "os-homedir": {
             "version": "1.0.2",
@@ -3041,9 +3068,9 @@
             }
         },
         "process-nextick-args": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
             "dev": true
         },
         "prompt": {
@@ -3139,6 +3166,15 @@
             "requires": {
                 "indent-string": "^3.0.0",
                 "strip-indent": "^2.0.0"
+            }
+        },
+        "regexp.prototype.flags": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
+            "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2"
             }
         },
         "release-zalgo": {
@@ -3808,21 +3844,22 @@
             }
         },
         "tfx-cli": {
-            "version": "0.7.3",
-            "resolved": "https://registry.npmjs.org/tfx-cli/-/tfx-cli-0.7.3.tgz",
-            "integrity": "sha512-lUuHtGbVjBZiQtrYHaT2jMWq2wIYDww8kjqm/mYM0OszcivpIl9g0w2/1J+fDnwv5hq6jX54VU1mvwU/BL/85A==",
+            "version": "0.7.9",
+            "resolved": "https://registry.npmjs.org/tfx-cli/-/tfx-cli-0.7.9.tgz",
+            "integrity": "sha512-hiMJC3aO+sf8kjCiGvKp+gQR0WsNWZnUfPfkPJjksIBVskfoF5tl+klN6LNosoWWP2Hot15KOdOoNU4cs8mM4A==",
             "dev": true,
             "requires": {
                 "app-root-path": "1.0.0",
                 "archiver": "2.0.3",
                 "async": "^1.4.0",
-                "azure-devops-node-api": "~7.2.0",
+                "azure-devops-node-api": "^8.1.1",
                 "clipboardy": "~1.2.3",
                 "colors": "~1.3.0",
                 "glob": "7.1.2",
+                "jju": "^1.4.0",
                 "json-in-place": "^1.0.1",
                 "jszip": "~3.1.5",
-                "lodash": "~4.17.0",
+                "lodash": "~4.17.11",
                 "minimist": "^1.1.2",
                 "mkdirp": "^0.5.1",
                 "onecolor": "^2.5.0",
@@ -4102,9 +4139,9 @@
                     "dev": true
                 },
                 "glob": {
-                    "version": "7.1.4",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-                    "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+                    "version": "7.1.5",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+                    "integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
                     "dev": true,
                     "requires": {
                         "fs.realpath": "^1.0.0",
@@ -4288,25 +4325,26 @@
             "dev": true
         },
         "xml2js": {
-            "version": "0.4.19",
-            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-            "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+            "version": "0.4.22",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.22.tgz",
+            "integrity": "sha512-MWTbxAQqclRSTnehWWe5nMKzI3VmJ8ltiJEco8akcC6j3miOhjjfzKum5sId+CWhfxdOs/1xauYr8/ZDBtQiRw==",
             "dev": true,
             "requires": {
                 "sax": ">=0.6.0",
-                "xmlbuilder": "~9.0.1"
+                "util.promisify": "~1.0.0",
+                "xmlbuilder": "~11.0.0"
             }
         },
         "xmlbuilder": {
-            "version": "9.0.7",
-            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+            "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
             "dev": true
         },
         "xtend": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
             "dev": true
         },
         "y18n": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-mirror-git-repository",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "A straightforward utility to mirror one Git repository to another location",
   "scripts": {
     "lint": "tslint -c tslint.json 'src/**/*.ts'",
@@ -19,6 +19,7 @@
     "prepackage": "npm run transpile && npm run package-deps && npm run package-task",
     "package": "tfx extension create --manifest-globs vss-extension.json",
     "pretask-upload": "npm run prepackage",
+    "tfx": "tfx",
     "tfx-login": "tfx login",
     "task-upload": "tfx build tasks upload --task-path .release/git-mirror/",
     "task-delete": "tfx build tasks delete --task-id 4e842f83-9438-4acb-994c-c8c31137dea9",
@@ -68,7 +69,7 @@
     "rimraf": "^3.0.0",
     "run-sequence": "^2.2.1",
     "sinon": "^7.3.2",
-    "tfx-cli": "^0.7.0",
+    "tfx-cli": "^0.7.9",
     "tslint": "^5.16.0",
     "tslint-no-unused-expression-chai": "^0.1.4",
     "typescript": "^3.4.4"

--- a/src/git-mirror/git-mirror-task.spec.ts
+++ b/src/git-mirror/git-mirror-task.spec.ts
@@ -66,7 +66,7 @@ describe("GitMirrorTask", () => {
         sinon.restore();
         task = null;
     });
-    
+
     describe("inputs", () => {
         it("should use correct config for source git repository", () => {
             expect(getInputStub.calledWith(sourceUriInputKey, true)).to.be.true;
@@ -106,7 +106,7 @@ describe("GitMirrorTask", () => {
         let gitPushMirrorStub: sinon.SinonStub;
         let removePullRequestRefsStub: sinon.SinonStub;
 
-        beforeEach(function() {         
+        beforeEach(function() {
             whichStub = sinon.stub(taskLib, "which");
             gitCloneMirrorStub = sinon.stub(task, "gitCloneMirror").resolves(0);
             removePullRequestRefsStub = sinon.stub(task, "removePullRequestRefs").resolves();
@@ -130,7 +130,7 @@ describe("GitMirrorTask", () => {
 
             expect(setResultStub.calledWith(taskLib.TaskResult.Failed)).to.be.false;
             expect(gitCloneMirrorStub.called).to.be.true;
-            expect(removePullRequestRefsStub.called).to.be.true;       
+            expect(removePullRequestRefsStub.called).to.be.true;
             expect(gitPushMirrorStub.called).to.be.true;
         });
 
@@ -142,7 +142,7 @@ describe("GitMirrorTask", () => {
 
             expect(setResultStub.calledWithExactly(taskLib.TaskResult.Failed, cloneErrMsg)).to.be.true;
             expect(gitCloneMirrorStub.called).to.be.true;
-            expect(removePullRequestRefsStub.called).to.be.false; 
+            expect(removePullRequestRefsStub.called).to.be.false;
             expect(gitPushMirrorStub.called).to.be.false;
         });
 
@@ -153,7 +153,7 @@ describe("GitMirrorTask", () => {
 
             expect(setResultStub.calledWithExactly(taskLib.TaskResult.Failed, err)).to.be.true;
             expect(gitCloneMirrorStub.called).to.be.true;
-            expect(removePullRequestRefsStub.called).to.be.false; 
+            expect(removePullRequestRefsStub.called).to.be.false;
             expect(gitPushMirrorStub.called).to.be.false;
         });
 
@@ -164,7 +164,7 @@ describe("GitMirrorTask", () => {
 
             expect(setResultStub.calledWithExactly(taskLib.TaskResult.Failed, err)).to.be.true;
             expect(gitCloneMirrorStub.called).to.be.true;
-            expect(removePullRequestRefsStub.called).to.be.true; 
+            expect(removePullRequestRefsStub.called).to.be.true;
             expect(gitPushMirrorStub.called).to.be.false;
         });
 
@@ -194,7 +194,7 @@ describe("GitMirrorTask", () => {
     });
 
     describe("mirror", () => {
-        const toolRunnerStub: ToolRunner = { 
+        const toolRunnerStub: ToolRunner = {
             arg: (val) => null,
             argIf: (condition, val) => null,
             exec: (options) => null
@@ -219,7 +219,7 @@ describe("GitMirrorTask", () => {
         describe("gitCloneMirror", () => {
             it("should construct and execute a 'git clone --mirror ...' task", () => {
                 task.gitCloneMirror();
-    
+
                 expect(getAuthenticatedGitUriStub.called).to.be.true;
                 expect(toolStub.calledWith("git")).to.be.true;
                 expect(argStub.firstCall.calledWith("clone")).to.be.true;
@@ -227,22 +227,22 @@ describe("GitMirrorTask", () => {
                 expect(argStub.thirdCall.calledWith(authenticatedUri)).to.be.true;
                 expect(execStub.called).to.be.true;
             });
-    
+
             it("should enable SSL certificate verification", () => {
                 task.getSourceVerifySSLCertificate = () => true;
                 getBoolInputStub.withArgs("sourceVerifySSLCertificate", false).callsFake(() => true);
                 task.gitCloneMirror();
-    
+
                 expect(getAuthenticatedGitUriStub.called).to.be.true;
                 expect(argIfStub.calledWithExactly(true, [ "-c", "http.sslVerify=true" ])).to.be.true;
                 expect(argIfStub.calledWithExactly(false, [ "-c", "http.sslVerify=false" ])).to.be.true;
                 expect(execStub.called).to.be.true;
             });
-    
+
             it("should disable SSL certificate verification", () => {
                 task.getSourceVerifySSLCertificate = () => false;
                 task.gitCloneMirror();
-    
+
                 expect(getAuthenticatedGitUriStub.called).to.be.true;
                 expect(argIfStub.calledWithExactly(false, [ "-c", "http.sslVerify=true" ])).to.be.true;
                 expect(argIfStub.calledWithExactly(true, [ "-c", "http.sslVerify=false" ])).to.be.true;
@@ -251,8 +251,8 @@ describe("GitMirrorTask", () => {
         });
 
         describe("removePullRequestRefs", () => {
-            const sourceRepoDirectory = "my-awesome-repo.git";
-            const expPackedRefsFile = `${sourceRepoDirectory}/packed-refs`;
+            const sourceRepoDirectory = "my-awesome-repo";
+            const expPackedRefsFile = `${sourceRepoDirectory}.git/packed-refs`;
             const expPackedRefsFullFilePath = `/usr/foo/repo/${expPackedRefsFile}`;
             let pathResolveStub: sinon.SinonStub;
             let pathJoinStub: sinon.SinonStub;
@@ -268,12 +268,12 @@ describe("GitMirrorTask", () => {
 
             const updatedPackedRefsFileContents = "data: # pack-refs with: peeled fully-peeled sorted \\n" +
             `${branchRef1}\\n${branchRef2}\\n${tagRef1}\\n${tagRef2}\\n`;
-    
+
             const originalPackedRefsFileContents = updatedPackedRefsFileContents +
                 `${pullRef1}\\n${pullRef2}\\n`;
-                
+
             beforeEach(() => {
-                task.getSourceGitFolder = () => sourceRepoDirectory;
+                task.getDefaultGitCloneDirectory = () => sourceRepoDirectory;
                 pathResolveStub = sinon.stub(path, "resolve").callsFake(() => expPackedRefsFullFilePath);
                 pathJoinStub = sinon.stub(path, "join").callsFake(() => expPackedRefsFile);
                 fsReadFileStub = sinon.stub(fs, "readFile").yields(null, originalPackedRefsFileContents);
@@ -282,7 +282,7 @@ describe("GitMirrorTask", () => {
 
             it("should reject when an error occurs", async () => {
                 const expErr = new Error("oops!");
-                task.getSourceGitFolder = () => { throw expErr; };
+                pathJoinStub.throws(expErr);
                 try {
                     await task.removePullRequestRefs();
                     expect(false).to.be.true;
@@ -319,40 +319,39 @@ describe("GitMirrorTask", () => {
                 expect(fsWriteFileSyncStub.calledWithExactly(expPackedRefsFullFilePath, updatedPackedRefsFileContents));
             });
         });
-    
+
         describe("gitPushMirror", () => {
-            const sourceFolder = "sourceFolder";
+            const sourceRepoGitDir = "vsts-mirror-git-repository.git";
             beforeEach(() => {
-                task.getSourceGitFolder = () => sourceFolder;
                 task.getDestinationVerifySSLCertificate = () => shouldVerifySSLCertificate;
                 task.getAuthenticatedGitUri = () => authenticatedUri;
             });
 
-            it("should construct and execute a 'git push --mirror ...' task", () => {   
+            it("should construct and execute a 'git push --mirror ...' task", () => {
                 task.gitPushMirror();
 
                 expect(toolStub.calledWith("git")).to.be.true;
                 expect(argStub.getCall(0).calledWith("-C")).to.be.true;
-                expect(argStub.getCall(1).calledWith(sourceFolder)).to.be.true;
+                expect(argStub.getCall(1).calledWith(sourceRepoGitDir)).to.be.true;
                 expect(argStub.getCall(2).calledWith("push")).to.be.true;
                 expect(argStub.getCall(3).calledWith("--mirror")).to.be.true;
                 expect(argStub.getCall(4).calledWith(authenticatedUri)).to.be.true;
                 expect(execStub.called).to.be.true;
             });
-            
+
             it("should enable SSL certificate verification", () => {
                 task.getDestinationVerifySSLCertificate = () => true;
                 task.gitPushMirror();
-    
+
                 expect(argIfStub.calledWithExactly(true, [ "-c", "http.sslVerify=true" ])).to.be.true;
                 expect(argIfStub.calledWithExactly(false, [ "-c", "http.sslVerify=false" ])).to.be.true;
                 expect(execStub.called).to.be.true;
             });
-            
+
             it("should disable SSL certificate verification", () => {
                 task.getDestinationVerifySSLCertificate = () => false;
                 task.gitPushMirror();
-    
+
                 expect(argIfStub.calledWithExactly(false, [ "-c", "http.sslVerify=true" ])).to.be.true;
                 expect(argIfStub.calledWithExactly(true, [ "-c", "http.sslVerify=false" ])).to.be.true;
                 expect(execStub.called).to.be.true;
@@ -384,28 +383,28 @@ describe("GitMirrorTask", () => {
         });
     });
 
-    describe("getSourceGitFolder", () => {
+    describe("getDefaultGitCloneDirectory", () => {
         it("should fail if the given URI is undefined", () => {
             const sourceGitUri = undefined;
             const expErrorMessage = buildInvalidURIErrorMessage(sourceGitUri);
-            expect(() => task.getSourceGitFolder(sourceGitUri)).to.throw(expErrorMessage);
+            expect(() => task.getDefaultGitCloneDirectory(sourceGitUri)).to.throw(expErrorMessage);
         });
 
         it("should fail if the given URI is not a valid URI", () => {
             const sourceGitUri = "invalidUri";
             const expErrorMessage = buildInvalidURIErrorMessage(sourceGitUri);
-            expect(() => task.getSourceGitFolder(sourceGitUri)).to.throw(expErrorMessage);
+            expect(() => task.getDefaultGitCloneDirectory(sourceGitUri)).to.throw(expErrorMessage);
         });
 
         it("should extract a folder name from a given uri", () => {
             const sourceGitUri = "https://github.com/swellaby/vsts-mirror-git-repository";
-            const folder = task.getSourceGitFolder(sourceGitUri);
+            const folder = task.getDefaultGitCloneDirectory(sourceGitUri);
             expect(folder).to.be.equal("vsts-mirror-git-repository.git");
         });
 
         it("should extract a folder name from a given uri with a .git extension", () => {
             const sourceGitUri = "https://github.com/swellaby/vsts-mirror-git-repository.git";
-            const folder = task.getSourceGitFolder(sourceGitUri);
+            const folder = task.getDefaultGitCloneDirectory(sourceGitUri);
             expect(folder).to.be.equal("vsts-mirror-git-repository.git");
         });
     });

--- a/src/git-mirror/git-mirror-task.spec.ts
+++ b/src/git-mirror/git-mirror-task.spec.ts
@@ -12,6 +12,7 @@ describe("GitMirrorTask", () => {
     const sourceUri = "https://github.com/swellaby/vsts-mirror-git-repository";
     const sourceUriInputKey = "sourceGitRepositoryUri";
     const sourcePAT = "xxxxxxxxxx";
+    const sourceRepoCloneDirInputKey = "sourceGitRepositoryCloneDirectoryName";
     const sourceTokenInputKey = "sourceGitRepositoryPersonalAccessToken";
     const sourceVerifySSLCertificate = true;
     const sourceSSLInputKey = "sourceVerifySSLCertificate";
@@ -195,9 +196,9 @@ describe("GitMirrorTask", () => {
 
     describe("mirror", () => {
         const toolRunnerStub: ToolRunner = {
-            arg: (val) => null,
-            argIf: (condition, val) => null,
-            exec: (options) => null
+            arg: (_val) => null,
+            argIf: (_condition, _val) => null,
+            exec: (_options) => null
         } as ToolRunner;
         const authenticatedUri = "authenticatedUri";
         const shouldVerifySSLCertificate = true;
@@ -217,7 +218,7 @@ describe("GitMirrorTask", () => {
         });
 
         describe("gitCloneMirror", () => {
-            it("should construct and execute a 'git clone --mirror ...' task", () => {
+            it("should construct and execute a 'git clone --mirror ...' task with default clone directory", () => {
                 task.gitCloneMirror();
 
                 expect(getAuthenticatedGitUriStub.called).to.be.true;
@@ -225,6 +226,23 @@ describe("GitMirrorTask", () => {
                 expect(argStub.firstCall.calledWith("clone")).to.be.true;
                 expect(argStub.secondCall.calledWith("--mirror")).to.be.true;
                 expect(argStub.thirdCall.calledWith(authenticatedUri)).to.be.true;
+                expect(argStub.getCall(3).calledWith("vsts-mirror-git-repository.git")).to.be.true;
+                expect(execStub.called).to.be.true;
+            });
+
+            it("should construct and execute a 'git clone --mirror ...' task with custom clone directory", () => {
+                const expectedCloneDir = "foo";
+                getInputStub.withArgs(sourceRepoCloneDirInputKey, false).callsFake(() => expectedCloneDir);
+                const task = new GitMirrorTask();
+                getAuthenticatedGitUriStub = sinon.stub(task, "getAuthenticatedGitUri").callsFake(() => authenticatedUri);
+                task.gitCloneMirror();
+
+                expect(getAuthenticatedGitUriStub.called).to.be.true;
+                expect(toolStub.calledWith("git")).to.be.true;
+                expect(argStub.firstCall.calledWith("clone")).to.be.true;
+                expect(argStub.secondCall.calledWith("--mirror")).to.be.true;
+                expect(argStub.thirdCall.calledWith(authenticatedUri)).to.be.true;
+                expect(argStub.getCall(3).calledWith(expectedCloneDir)).to.be.true;
                 expect(execStub.called).to.be.true;
             });
 
@@ -303,9 +321,18 @@ describe("GitMirrorTask", () => {
                 }
             });
 
-            it("should use correct file path to packed-refs file", async () => {
+            it("should use correct file path to packed-refs file with default source clone directory", async () => {
                 await task.removePullRequestRefs();
                 expect(pathJoinStub.calledWithExactly(".", expPackedRefsFile));
+                expect(pathResolveStub.calledWithExactly(expPackedRefsFile)).to.be.true;
+            });
+
+            it("should use correct file path to packed-refs file with custom source clone directory", async () => {
+                const expectedCloneDir = "bar";
+                getInputStub.withArgs(sourceRepoCloneDirInputKey, false).callsFake(() => expectedCloneDir);
+                await new GitMirrorTask().removePullRequestRefs();
+
+                expect(pathJoinStub.calledWithExactly(".", `${expectedCloneDir}/packed-refs`));
                 expect(pathResolveStub.calledWithExactly(expPackedRefsFile)).to.be.true;
             });
 
@@ -327,12 +354,28 @@ describe("GitMirrorTask", () => {
                 task.getAuthenticatedGitUri = () => authenticatedUri;
             });
 
-            it("should construct and execute a 'git push --mirror ...' task", () => {
+            it("should construct and execute a 'git push --mirror ...' task with default source clone directory", () => {
                 task.gitPushMirror();
 
                 expect(toolStub.calledWith("git")).to.be.true;
                 expect(argStub.getCall(0).calledWith("-C")).to.be.true;
                 expect(argStub.getCall(1).calledWith(sourceRepoGitDir)).to.be.true;
+                expect(argStub.getCall(2).calledWith("push")).to.be.true;
+                expect(argStub.getCall(3).calledWith("--mirror")).to.be.true;
+                expect(argStub.getCall(4).calledWith(authenticatedUri)).to.be.true;
+                expect(execStub.called).to.be.true;
+            });
+
+            it("should construct and execute a 'git push --mirror ...' task with custom source clone directory", () => {
+                const expectedCloneDir = "baz";
+                getInputStub.withArgs(sourceRepoCloneDirInputKey, false).callsFake(() => expectedCloneDir);
+                const task = new GitMirrorTask();
+                task.getAuthenticatedGitUri = () => authenticatedUri;
+                task.gitPushMirror();
+
+                expect(toolStub.calledWith("git")).to.be.true;
+                expect(argStub.getCall(0).calledWith("-C")).to.be.true;
+                expect(argStub.getCall(1).calledWith(expectedCloneDir)).to.be.true;
                 expect(argStub.getCall(2).calledWith("push")).to.be.true;
                 expect(argStub.getCall(3).calledWith("--mirror")).to.be.true;
                 expect(argStub.getCall(4).calledWith(authenticatedUri)).to.be.true;

--- a/src/git-mirror/task.json
+++ b/src/git-mirror/task.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 1,
     "Minor": 1,
-    "Patch": 9
+    "Patch": 10
   },
   "instanceNameFormat": "Mirror Git Repository to $(destinationGitRepositoryUri)",
   "inputs": [

--- a/src/git-mirror/task.json
+++ b/src/git-mirror/task.json
@@ -30,6 +30,14 @@
       "defaultValue": ""
     },
     {
+      "name": "sourceGitRepositoryCloneDirectoryName",
+      "type": "string",
+      "label": "Source Repository - Clone Directory Name",
+      "required": false,
+      "helpMarkDown": "(Optional) The name of a directory to clone the source repo into",
+      "defaultValue": ""
+    },
+    {
       "name": "sourceVerifySSLCertificate",
       "type": "boolean",
       "label": "Verify SSL Certificate on Source Repository",

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "mirror-git-repository",
   "name": "Mirror Git Repository",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "publisher": "Swellaby",
   "tags": ["git", "clone", "push", "mirror", "--mirror", "repo", "repository"],
   "targets": [{


### PR DESCRIPTION
## Changes
Summary of changes included in this PR:
- [x] Adds a new (optional) input to allow users to override the directory the source repo is cloned into
- [x] Updates to `tfx-cli` to v0.7.9 which includes the fix for invalid task name validation
- [x] Minor doc updates

## Related Issues
- Resolves #51

I also set up a few additional test pipelines in our Task Validation org with this new version, including the multiple task instances with the same repo name

https://dev.azure.com/swellaby-azp-task-validation/OpenSource/_build?definitionId=7&_a=summary
https://dev.azure.com/swellaby-azp-task-validation/OpenSource/_build?definitionId=8&_a=summary


CC - @traviskosarek @calebcartwright