### PR TITLE
change destinationGitRepositoryPersonalAccessToken to not be required

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Verifying SSL certificates is a default behavior of Git. Disabling this option w
 The HTTPS endpoint of the Git Repository you want to copy to. This field is **required**.
 
 **Destination Repository - Personal Access Token**
-A Personal Access Token (PAT) that grants write access to the repository in the `Destination Git Repository` field. This field is **required**. Check out the **Best Practices** section below for more details on managing PAT Tokens securely.
+A Personal Access Token (PAT) that grants write access to the repository in the `Destination Git Repository` field. This field is **optional**. Check out the **Best Practices** section below for more details on managing PAT Tokens securely.
 
 **Verify SSL Certificate on Destination Repository**
 Verifiying SSL certificates is a default behavior of Git. Unchecking this option will turn off SSL certificate validation as a part of the Destination Repository push process. _If you are using a Git server with a Self-Signing certificate, you will likely need to uncheck this option._

--- a/src/git-mirror/task.json
+++ b/src/git-mirror/task.json
@@ -57,7 +57,7 @@
       "name": "destinationGitRepositoryPersonalAccessToken",
       "type": "string",
       "label": "Destination Repository - Personal Access Token",
-      "required": true,
+      "required": false,
       "helpMarkDown": "A Personal Access Token that grants write access to the Git repository used as the Destination Git Repository",
       "defaultValue": ""
     },


### PR DESCRIPTION
The documentation inconsistently declares "Destination Repository - Personal Access Token" as both required and optional in different sections. The code already appears to handle `destinationGitRepositoryPersonalAccessToken` being undefined so this simply updates the one mention that the field is required and changes the `task.json` to make it optional. This allows pushing to repositories that don't have authentication.

NB: The other mention that `destinationGitRepositoryPersonalAccessToken` can be omitted is in `README.md` @ line 63

Haven't added any extra tests as this only alters the `task.json` declaration, not the functionality and the `getAuthenticatedGitUri` tests already cover this case.

## Changes
Summary of changes included in this PR:
- `destinationGitRepositoryPersonalAccessToken` is now optional

CC - @traviskosarek @calebcartwright